### PR TITLE
chore: change module main entry

### DIFF
--- a/.changeset/strong-falcons-sleep.md
+++ b/.changeset/strong-falcons-sleep.md
@@ -1,0 +1,5 @@
+---
+'@pagerduty/backstage-plugin': patch
+---
+
+Change module main entry for backstage-plugin (frontend)

--- a/plugins/backstage-plugin/package.json
+++ b/plugins/backstage-plugin/package.json
@@ -2,12 +2,12 @@
   "name": "@pagerduty/backstage-plugin",
   "description": "A Backstage plugin that integrates towards PagerDuty",
   "version": "0.15.8",
-  "main": "dist/index.cjs.js",
+  "main": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public",
-    "main": "dist/index.cjs.js",
+    "main": "dist/index.esm.js",
     "types": "dist/index.d.ts"
   },
   "backstage": {


### PR DESCRIPTION
### Description

There is an issue with the main entry for the backstage-plugin which prevents users from running tests, due to a `Cannot find module @pagerduty/backstage-plugin from ...`. This fix the issue by setting as main entry the exact file distributed via npmjs.

**Issue number:** (e.g. #123)
[#54](https://github.com/PagerDuty/backstage-plugins/issues/54)

### Affected plugin

- [x] backstage-plugin
- [ ] backstage-plugin-backend
- [ ] backstage-plugin-scaffolder-actions
- [ ] backstage-plugin-entity-processor

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented
- [x] Changes generate *no new warnings*
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.