### PR TITLE
feat: Allow default Backstage auth policy on plugin route

### DIFF
--- a/plugins/backstage-plugin-backend/src/plugin.ts
+++ b/plugins/backstage-plugin-backend/src/plugin.ts
@@ -12,7 +12,7 @@ class CatalogFetchApi {
   constructor(
     private readonly logger: LoggerService,
     private readonly auth: AuthService,
-  ) {}
+  ) { }
 
   async fetch(
     input: unknown,
@@ -62,10 +62,17 @@ export const pagerDutyPlugin = createBackendPlugin({
             }),
           }),
         );
-        httpRouter.addAuthPolicy({
-          path: '/',
-          allow: 'unauthenticated',
-        });
+        // The default Backstage behaviour is to require authentication on routes.
+        // https://backstage.io/docs/backend-system/core-services/http-router/#using-the-service
+        // Setting disableUnauthenticatedAccess to true will revert this plugin's route authentication
+        // policy back to the default Backstage behaviour.
+        const disableUnauthenticatedAccess = config.getOptionalBoolean('pagerDuty.disableUnauthenticatedAccess') ?? false;
+        if (!disableUnauthenticatedAccess) {
+          httpRouter.addAuthPolicy({
+            path: '/',
+            allow: 'unauthenticated',
+          });
+        }
       },
     });
   },


### PR DESCRIPTION
### Description

This is a recreation of https://github.com/PagerDuty/backstage-plugin-backend/pull/114.

Corresponding documentation update: https://github.com/PagerDuty/backstage-plugin-docs/pull/14

Currently, any user that is able to access a Backstage instance that has the PagerDuty plugin installed can make proxied calls to the PagerDuty API without needing a user session in Backstage, e.g.

curl "https://${BACKSTAGE_HOST}/api/pagerduty/services"
The above will return a list of all the services in the account, and presumably can make other proxied API calls to the rest of the PagerDuty API, subject to the permissions of the API token available in Backstage.

This PR adds opt-in support to disable the unauthenticated policy, which [Backstage's own documentation](https://backstage.io/docs/backend-system/core-services/http-router/#using-the-service:~:text=This%20dangerously%20allows%20unauthenticated%20access%20on%20a%20specific%20route) refers to as dangerous.

Ideally this would be more of an opt-out feature, but I don't have visibility into current usage of this plugin, so I'm leaving it as opt-in for now.

I've tested this in a local instance of Backstage, and can confirm I get an HTTP 401 when attempting to run the same curl command as above without a valid Authorization: Bearer ... header.

### Affected plugin

- [ ] backstage-plugin
- [X] backstage-plugin-backend
- [ ] backstage-plugin-scaffolder-actions
- [ ] backstage-plugin-entity-processor

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [X] I have performed a self-review of this change
- [ ] Changes have been tested
- [X] Changes are documented (https://github.com/PagerDuty/backstage-plugin-docs/pull/14)
- [ ] Changes generate *no new warnings*
- [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.