### PR TITLE
Get rid of past changesets

### DIFF
--- a/.changeset/great-cooks-crash.md
+++ b/.changeset/great-cooks-crash.md
@@ -1,5 +1,0 @@
----
-'@pagerduty/backstage-plugin-backend': patch
----
-
-Remove remainings of old backend system

--- a/.changeset/heavy-chefs-rhyme.md
+++ b/.changeset/heavy-chefs-rhyme.md
@@ -1,5 +1,0 @@
----
-'@pagerduty/backstage-plugin': patch
----
-
-Migrate backstage plugin's EntityPagerDutyCard to Backstage UI

--- a/.changeset/quick-signs-switch.md
+++ b/.changeset/quick-signs-switch.md
@@ -1,5 +1,0 @@
----
-'@pagerduty/backstage-plugin': patch
----
-
-Migrated the PagerDutyCard component to backtage ui

--- a/.changeset/sad-teeth-show.md
+++ b/.changeset/sad-teeth-show.md
@@ -1,8 +1,0 @@
----
-'@pagerduty/backstage-plugin-scaffolder-actions': patch
-'@pagerduty/backstage-plugin-entity-processor': patch
-'@pagerduty/backstage-plugin-backend': patch
-'@pagerduty/backstage-plugin': patch
----
-
-Fix package.json metadata to improve Portal relations

--- a/.changeset/slimy-mangos-write.md
+++ b/.changeset/slimy-mangos-write.md
@@ -1,9 +1,0 @@
----
-'@pagerduty/backstage-plugin': minor
----
-
-Best practice implementation of the new frontend system
-
-- Better separation of concerns.
-- New use of the API for new frontend system.
-- Made the @backstage/ui dependency a peer-dependency that needs to be imported and used by Backstage users.

--- a/.changeset/strong-falcons-sleep.md
+++ b/.changeset/strong-falcons-sleep.md
@@ -1,5 +1,0 @@
----
-'@pagerduty/backstage-plugin': patch
----
-
-Change module main entry for backstage-plugin (frontend)

--- a/.changeset/three-lemons-return.md
+++ b/.changeset/three-lemons-return.md
@@ -1,5 +1,0 @@
----
-'@pagerduty/backstage-plugin': patch
----
-
-Implement new frontend system (alpha)


### PR DESCRIPTION
### Description

Remove unused changeset files

### Affected plugin

- [ ] backstage-plugin
- [ ] backstage-plugin-backend
- [ ] backstage-plugin-scaffolder-actions
- [ ] backstage-plugin-entity-processor

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [ ] I have performed a self-review of this change
- [ ] Changes have been tested
- [ ] Changes have been tested in dark theme
- [ ] Changes are documented
- [ ] Changes generate _no new warnings_
- [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
