### PR TITLE
Fix: remove backstage UI css files

### DIFF
--- a/.changeset/sharp-chairs-unite.md
+++ b/.changeset/sharp-chairs-unite.md
@@ -1,5 +1,0 @@
----
-'@pagerduty/backstage-plugin': patch
----
-
-Update README

--- a/.changeset/tall-bears-jump.md
+++ b/.changeset/tall-bears-jump.md
@@ -1,0 +1,5 @@
+---
+'@pagerduty/backstage-plugin': patch
+---
+
+Remove Backstage UI CSS imports from frontend plugin

--- a/packages/app/src/index.tsx
+++ b/packages/app/src/index.tsx
@@ -1,6 +1,5 @@
 import '@backstage/cli/asset-types';
 import ReactDOM from 'react-dom/client';
-import '@backstage/canon/css/styles.css';
 import '@backstage/ui/css/styles.css';
 
 // Uncomment the lines below if you want to use the old version of the app

--- a/plugins/backstage-plugin/README.md
+++ b/plugins/backstage-plugin/README.md
@@ -145,6 +145,12 @@ Now the PagerDuty plugin will display in all your components that include PagerD
 >
 > The code samples provided above reflect the default configuration of the PagerDutyCard entity. You have at your disposal some parameters that allow you to [prevent users from creating incidents](https://pagerduty.github.io/backstage-plugin-docs/advanced/enable-read-only-mode), or [hide the change events tab](https://pagerduty.github.io/backstage-plugin-docs/advanced/hide-change-events) or even [hide the on-call](https://pagerduty.github.io/backstage-plugin-docs/advanced/hide-oncall) section of the card.
 
+> 🚨 Important
+>
+> From version 0.16.0 and later, you need to import the Backstage UI CSS at the root (`src/index.tsx`) of
+your backstage application (`import '@backstage/ui/css/styles.css'`), otherwise the Plugin
+widgets won't look as they should.
+
 ### Configure the Frontend plugin
 
 You’ve now added the PagerDuty frontend plugin to your application, but in order for it to show up you will need to configure your entities and the application itself.

--- a/plugins/backstage-plugin/src/alpha/plugin.ts
+++ b/plugins/backstage-plugin/src/alpha/plugin.ts
@@ -21,7 +21,6 @@ import { pagerDutyPage } from "../alpha/pages";
 import { pagerDutyNavBarItem } from "../alpha/nav-items";
 import { convertLegacyRouteRefs } from "@backstage/core-compat-api";
 import { rootRouteRef } from "../routes";
-import '@backstage/ui/css/styles.css';
 
 /** @alpha */
 export const pagerDutyPlugin = createFrontendPlugin({


### PR DESCRIPTION
### Description

There was an issue with the current version of the frontend plugin in which it changed the looks of Portal instances because there was an import of the backstage ui CSS files. By removing Portal instances get back their look and feel. This creates a caveat in which, from now on, Backstage users should include that file themselves to preserve the look and feel of the PagerDuty plugins.

### Affected plugin

- [x] backstage-plugin
- [ ] backstage-plugin-backend
- [ ] backstage-plugin-scaffolder-actions
- [ ] backstage-plugin-entity-processor

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes have been tested in dark theme
- [x] Changes are documented
- [x] Changes generate _no new warnings_
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
