### PR TITLE
feat: Add filtering capabilities to service mapping table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ db
 
 # Claude code
 .claude
+CLAUDE.md

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,6 @@
 {
   "singleQuote": true,
   "trailingComma": "all",
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "printWidth": 120
 }

--- a/app-config.yaml
+++ b/app-config.yaml
@@ -9,9 +9,14 @@ backend:
   # Used for enabling authentication, secret is shared by all backend plugins
   # See https://backstage.io/docs/auth/service-to-service-auth for
   # information on the format
-  # auth:
-  #   keys:
-  #     - secret: ${BACKEND_SECRET}
+  auth:
+    # keys:
+    #   - secret: ${BACKEND_SECRET}
+    externalAccess:
+      - type: static
+        options:
+          token: ${STATIC_API_TOKEN}
+          subject: api-client
   baseUrl: http://localhost:7007
   listen:
     port: 7007

--- a/plugins/backstage-plugin-backend/src/apis/pagerduty.ts
+++ b/plugins/backstage-plugin-backend/src/apis/pagerduty.ts
@@ -889,7 +889,6 @@ export async function getAllServices(): Promise<PagerDutyService[]> {
 
           result = (await response.json()) as PagerDutyServicesAPIResponse;
 
-          // set account
           result.services.forEach(service => {
             service.account = account;
           });
@@ -970,7 +969,6 @@ export async function getServicesByPartialName(
 
           result = (await response.json()) as PagerDutyServicesAPIResponse;
 
-          // set account
           result.services.forEach(service => {
             service.account = account;
           });

--- a/plugins/backstage-plugin-backend/src/controllers/mappings-controller.ts
+++ b/plugins/backstage-plugin-backend/src/controllers/mappings-controller.ts
@@ -1,0 +1,436 @@
+import { Request, Response } from 'express';
+import * as Pagerduty from '../services/pagerduty';
+import * as CatalogEntityUtils from '../utils/catalog-entity';
+import { PagerDutyBackendStore } from '../db';
+import { CatalogApi, GetEntitiesResponse, QueryEntitiesResponse } from '@backstage/catalog-client';
+import { HttpError, PagerDutyEntityMappingsResponse, PagerDutyService } from '@pagerduty/backstage-plugin-common';
+import { getServiceByIntegrationKey, getServicesByIds } from '../apis/pagerduty';
+import { RawDbEntityResultRow } from '../db/PagerDutyBackendDatabase';
+
+export function getMappingEntities(store: PagerDutyBackendStore, catalogApi: CatalogApi | undefined) {
+  return async function getMappingEntitiesFunction(request: Request, response: Response) {
+    try {
+      const { offset = 0, limit = 10, filters = {} } = request.body;
+
+      if (typeof offset !== 'number' || typeof limit !== 'number' || offset < 0 || limit <= 0) {
+        response
+          .status(400)
+          .json({ errors: ["Bad Request: 'offset' and 'limit' must be valid numbers"] });
+
+        return;
+      }
+
+      const hasStatusFilter = filters?.status?.trim();
+      const hasNameFilter = filters?.name?.trim();
+      const hasTeamNameFilter = filters?.teamName?.trim();
+      const needsBothFullTextFilters = hasNameFilter && hasTeamNameFilter;
+      const needsPostProcessing = hasStatusFilter || needsBothFullTextFilters;
+
+      const queryOptions: {
+        filter: Array<{
+          kind: string;
+          'metadata.namespace'?: string;
+          'metadata.name'?: string;
+        }>;
+        limit: number;
+        offset: number;
+        fullTextFilter?: { term: string; fields: string[] };
+      } = {
+        filter: [{ kind: 'Component' }],
+        limit: needsPostProcessing ? 10000 : limit,
+        offset: needsPostProcessing ? 0 : offset,
+      };
+
+      if (filters?.serviceName?.trim()) {
+        const serviceQuery = filters.serviceName.trim();
+
+        const matchingPagerDutyServiceIds = await Pagerduty.getServicesIdsByPartialName(serviceQuery);
+
+        if (matchingPagerDutyServiceIds.length > 0) {
+          const entityMappings = await store.getAllEntityMappings();
+
+          const mappingsWithMatchingPagerdutyServices = entityMappings.filter(
+            mapping => matchingPagerDutyServiceIds.includes(mapping.serviceId),
+          );
+
+          const entityRefs: Array<string> =
+            mappingsWithMatchingPagerdutyServices
+              .map(mapping => mapping.entityRef)
+              .filter(Boolean);
+
+          if (entityRefs.length > 0) {
+            // extract shape of { kind: 'Component', 'metadata.namespace': string, 'metadata.name': string }
+            queryOptions.filter = entityRefs.map(_extractQueryFilterFromEntityRef).filter(f => f !== null);
+
+            if (queryOptions.filter.length === 0) {
+              response.json({ entities: [], totalCount: 0 });
+              return;
+            }
+          } else {
+            response.json({ entities: [], totalCount: 0 });
+            return;
+          }
+        } else {
+          response.json({ entities: [], totalCount: 0 });
+          return;
+        }
+      }
+
+      const componentEntities = await _queryEntitiesWithFilters(
+        catalogApi!,
+        queryOptions,
+        filters.name,
+        filters.teamName,
+      );
+
+      const allEntityMappings = await store.getAllEntityMappings();
+
+      const currentPageMappings = allEntityMappings.filter(mapping => {
+        return componentEntities.items.some(entity => {
+          const entityRef = CatalogEntityUtils.entityRef(entity).toLowerCase();
+
+          const integrationKey = CatalogEntityUtils.getPagerDutyIntegrationKey(entity);
+
+          return (mapping.entityRef === entityRef || mapping.integrationKey === integrationKey);
+        });
+      });
+
+      const currentPagePagerDutyServiceIds = currentPageMappings.map(mapping => mapping.serviceId).filter(Boolean);
+
+      const currentPagePagerDutyServices = await getServicesByIds(currentPagePagerDutyServiceIds);
+
+      const componentEntitiesDict =
+        await CatalogEntityUtils.createComponentEntitiesReferenceDict(componentEntities);
+
+      const maps = await _buildEntityMappingsResponse(
+        allEntityMappings,
+        componentEntitiesDict,
+        componentEntities,
+        currentPagePagerDutyServices,
+      );
+
+      let formattedEntities = await Promise.all(
+        componentEntities.items.map(async entity => {
+          const annotations = {
+            'pagerduty.com/integration-key': CatalogEntityUtils.getPagerDutyIntegrationKey(entity) ?? '',
+            'pagerduty.com/service-id': CatalogEntityUtils.getPagerDutyServiceId(entity) ?? '',
+          };
+
+          const formattedEntity = {
+            name: entity.metadata?.name,
+            id: entity.metadata?.uid ?? '',
+            namespace: entity.metadata?.namespace ?? '',
+            type: entity.kind ?? '',
+            system: entity.spec?.system ? JSON.stringify(entity.spec?.system) : '',
+            owner: entity.spec?.owner ? JSON.stringify(entity.spec?.owner) : '',
+            lifecycle: entity.spec?.lifecycle ? JSON.stringify(entity.spec?.lifecycle) : '',
+            annotations,
+            status: 'NotMapped',
+            serviceName: '',
+            serviceUrl: '',
+            team: '',
+            escalationPolicy: '',
+            account: '',
+          };
+
+          // Try to find a service by service ID or integration key
+          let service = null;
+          let isServiceError = null;
+
+          if (annotations['pagerduty.com/service-id']) {
+            const serviceId = annotations['pagerduty.com/service-id'];
+            service = currentPagePagerDutyServices.find(s => s.id === serviceId);
+          } else if (annotations['pagerduty.com/integration-key']) {
+            const integrationKey = annotations['pagerduty.com/integration-key'];
+            const account = entity.metadata?.annotations?.['pagerduty.com/account'] || '';
+
+            try {
+              service = await getServiceByIntegrationKey(integrationKey, account);
+            } catch (e) {
+              if (e instanceof HttpError && e.status !== 404) {
+                isServiceError = true;
+              }
+            }
+          }
+
+          const entityRef = CatalogEntityUtils.entityRef(entity).toLowerCase();
+
+          const entityMapping = maps.mappings.find(
+            mapping =>
+              mapping.entityRef === entityRef ||
+              (mapping.integrationKey && mapping.integrationKey ===  annotations['pagerduty.com/integration-key']) ||
+              (mapping.serviceId && mapping.serviceId === annotations['pagerduty.com/service-id']),
+          );
+
+          if (service) {
+            formattedEntity.serviceName = service.name;
+            formattedEntity.serviceUrl = service.html_url;
+            formattedEntity.team = service.teams?.[0]?.name ?? '';
+            formattedEntity.escalationPolicy = service.escalation_policy?.name ?? '';
+            formattedEntity.account = service.account || '';
+
+            if (entityMapping) {
+              const expectedEntityRef = componentEntitiesDict[service.id]?.ref;
+
+              if (expectedEntityRef && expectedEntityRef === entityMapping.entityRef) {
+                formattedEntity.status = entityMapping.status || 'NotMapped';
+              } else {
+                formattedEntity.status = 'NotMapped';
+              }
+            }
+          } else if (isServiceError) {
+            formattedEntity.status = 'ErrorWhenFetchingService';
+          }
+
+          return formattedEntity;
+        }),
+      );
+
+      if (hasStatusFilter) {
+        formattedEntities = formattedEntities.filter(entity => entity.status === filters.status.trim());
+      }
+
+      const totalCount = needsPostProcessing ? formattedEntities.length : componentEntities.totalItems;
+
+      const paginatedEntities = needsPostProcessing
+        ? formattedEntities.slice(offset, offset + limit)
+        : formattedEntities;
+
+      response.json({
+        entities: paginatedEntities,
+        totalCount,
+      });
+    } catch (error) {
+      if (error instanceof HttpError) {
+        response.status(error.status).json({
+          errors: [`${error.message}`],
+        });
+      }
+    }
+  };
+}
+
+function _extractQueryFilterFromEntityRef(entityRef: string) {
+  const [, namespaceAndName] = entityRef.split(':');
+
+  if (!namespaceAndName) {
+    return null;
+  }
+
+  const [namespace, name] = namespaceAndName.split('/');
+
+  return {
+    kind: 'Component',
+    'metadata.namespace': namespace,
+    'metadata.name': name,
+  };
+}
+
+async function _queryEntitiesWithFilters(
+  catalog: CatalogApi,
+  baseQueryOptions: {
+    filter: Array<{
+      kind: string;
+      'metadata.namespace'?: string;
+      'metadata.name'?: string;
+    }>;
+    limit: number;
+    offset: number;
+  },
+  nameFilter?: string,
+  teamNameFilter?: string,
+): Promise<QueryEntitiesResponse> {
+  const hasNameFilter = nameFilter?.trim();
+  const hasTeamNameFilter = teamNameFilter?.trim();
+
+  if (hasNameFilter && hasTeamNameFilter) {
+    const [nameResults, teamResults] = await Promise.all([
+      catalog.queryEntities({
+        ...baseQueryOptions,
+        fullTextFilter: {
+          term: hasNameFilter,
+          fields: ['metadata.name'],
+        },
+      }),
+      catalog.queryEntities({
+        ...baseQueryOptions,
+        fullTextFilter: {
+          term: hasTeamNameFilter,
+          fields: ['spec.owner'],
+        },
+      }),
+    ]);
+
+    const nameResultUids = new Set(nameResults.items.map(entity => entity.metadata?.uid).filter(Boolean));
+
+    const intersectedEntities = teamResults.items.filter(entity => nameResultUids.has(entity.metadata?.uid));
+
+    return {
+      items: intersectedEntities,
+      totalItems: intersectedEntities.length,
+      pageInfo: teamResults.pageInfo,
+    };
+  }
+
+  const queryOptions: {
+    filter: Array<{
+      kind: string;
+      'metadata.namespace'?: string;
+      'metadata.name'?: string;
+    }>;
+    limit: number;
+    offset: number;
+    fullTextFilter?: { term: string; fields: string[] };
+  } = { ...baseQueryOptions };
+
+  if (hasNameFilter) {
+    queryOptions.fullTextFilter = {
+      term: hasNameFilter,
+      fields: ['metadata.name'],
+    };
+  } else if (hasTeamNameFilter) {
+    queryOptions.fullTextFilter = {
+      term: hasTeamNameFilter,
+      fields: ['spec.owner'],
+    };
+  }
+
+  return catalog.queryEntities(queryOptions);
+}
+
+async function _buildEntityMappingsResponse(
+  entityMappings: RawDbEntityResultRow[],
+  componentEntitiesDict: Record<string, { ref: string; name: string; }>,
+  componentEntities: GetEntitiesResponse,
+  pagerDutyServices: PagerDutyService[],
+): Promise<PagerDutyEntityMappingsResponse> {
+  const result: PagerDutyEntityMappingsResponse = {
+    mappings: [],
+  };
+
+  pagerDutyServices.forEach(service => {
+    const entityRef = componentEntitiesDict[service.id]?.ref;
+    const entityName = componentEntitiesDict[service.id]?.name;
+
+    const entityMapping = entityMappings.find(mapping => mapping.serviceId === service.id);
+
+    if (entityMapping) {
+      if (entityRef === undefined) {
+        if (entityMapping.entityRef === '' ||entityMapping.entityRef === undefined) {
+          result.mappings.push({
+            entityRef: '',
+            entityName: '',
+            integrationKey: entityMapping.integrationKey,
+            serviceId: entityMapping.serviceId,
+            status: 'NotMapped',
+            serviceName: service.name,
+            team: service.teams?.[0]?.name ?? '',
+            escalationPolicy: service.escalation_policy !== undefined ? service.escalation_policy.name : '',
+            serviceUrl: service.html_url,
+            account: service.account,
+          });
+        } else {
+          const entityRefName =
+            componentEntities.items.find(
+              entity =>
+                `${entity.kind}:${entity.metadata.namespace}/${entity.metadata.name}`.toLowerCase() ===
+                entityMapping.entityRef,
+            )?.metadata.name ?? '';
+
+          result.mappings.push({
+            entityRef: entityMapping.entityRef,
+            entityName: entityRefName,
+            serviceId: entityMapping.serviceId,
+            integrationKey: entityMapping.integrationKey,
+            status: 'OutOfSync',
+            serviceName: service.name,
+            team: service.teams?.[0]?.name ?? '',
+            escalationPolicy: service.escalation_policy !== undefined ? service.escalation_policy.name : '',
+            serviceUrl: service.html_url,
+            account: service.account,
+          });
+        }
+      } else if (entityRef !== entityMapping.entityRef) {
+        const entityRefName =
+          componentEntities.items.find(
+            entity =>
+              `${entity.kind}:${entity.metadata.namespace}/${entity.metadata.name}`.toLowerCase() ===
+              entityMapping.entityRef,
+          )?.metadata.name ?? '';
+
+        result.mappings.push({
+          entityRef: entityMapping.entityRef !== '' ? entityMapping.entityRef : '',
+          entityName: entityMapping.entityRef !== '' ? entityRefName : '',
+          serviceId: entityMapping.serviceId,
+          integrationKey: entityMapping.integrationKey,
+          status: 'OutOfSync',
+          serviceName: service.name,
+          team: service.teams?.[0]?.name ?? '',
+          escalationPolicy: service.escalation_policy !== undefined ? service.escalation_policy.name : '',
+          serviceUrl: service.html_url,
+          account: service.account,
+        });
+      } else if (entityRef === entityMapping.entityRef) {
+        result.mappings.push({
+          entityRef: entityMapping.entityRef !== '' ? entityMapping.entityRef : '',
+          entityName: entityMapping.entityRef !== '' ? entityName : '',
+          serviceId: entityMapping.serviceId,
+          integrationKey: entityMapping.integrationKey,
+          status: 'InSync',
+          serviceName: service.name,
+          team: service.teams?.[0]?.name ?? '',
+          escalationPolicy: service.escalation_policy !== undefined ? service.escalation_policy.name : '',
+          serviceUrl: service.html_url,
+          account: service.account,
+        });
+      }
+    } else {
+      const backstageVendorId = 'PRO19CT';
+      const backstageIntegrationKey =
+        service.integrations?.find(
+          integration => integration.vendor?.id === backstageVendorId,
+        )?.integration_key ?? '';
+
+      if (entityRef !== undefined) {
+        result.mappings.push({
+          entityRef: entityRef,
+          entityName: entityName,
+          serviceId: service.id,
+          integrationKey: backstageIntegrationKey,
+          status: 'InSync',
+          serviceName: service.name,
+          team: service.teams?.[0]?.name ?? '',
+          escalationPolicy: service.escalation_policy !== undefined ? service.escalation_policy.name : '',
+          serviceUrl: service.html_url,
+          account: service.account,
+        });
+      } else {
+        result.mappings.push({
+          entityRef: '',
+          entityName: '',
+          serviceId: service.id,
+          integrationKey: backstageIntegrationKey,
+          status: 'NotMapped',
+          serviceName: service.name,
+          team: service.teams?.[0]?.name ?? '',
+          escalationPolicy: service.escalation_policy !== undefined ? service.escalation_policy.name : '',
+          serviceUrl: service.html_url,
+          account: service.account,
+        });
+      }
+    }
+  });
+
+  const sortedResult = result.mappings.sort((a, b) => {
+    if (a.serviceName! < b.serviceName!) {
+      return -1;
+    } else if (a.serviceName! > b.serviceName!) {
+      return 1;
+    }
+    return 0;
+  });
+
+  result.mappings = sortedResult;
+
+  return result;
+}

--- a/plugins/backstage-plugin-backend/src/controllers/mappings-controller.ts
+++ b/plugins/backstage-plugin-backend/src/controllers/mappings-controller.ts
@@ -23,8 +23,9 @@ export function getMappingEntities(store: PagerDutyBackendStore, catalogApi: Cat
       const hasStatusFilter = filters?.status?.trim();
       const hasNameFilter = filters?.name?.trim();
       const hasTeamNameFilter = filters?.teamName?.trim();
+      const hasAccountFilter = filters?.account?.trim();
       const needsBothFullTextFilters = hasNameFilter && hasTeamNameFilter;
-      const needsPostProcessing = hasStatusFilter || needsBothFullTextFilters;
+      const needsPostProcessing = hasStatusFilter || needsBothFullTextFilters || hasAccountFilter;
 
       const queryOptions: {
         filter: Array<{
@@ -188,6 +189,12 @@ export function getMappingEntities(store: PagerDutyBackendStore, catalogApi: Cat
 
       if (hasStatusFilter) {
         formattedEntities = formattedEntities.filter(entity => entity.status === filters.status.trim());
+      }
+
+      if (hasAccountFilter) {
+        formattedEntities = formattedEntities.filter(entity =>
+          entity.account?.toLowerCase().includes(filters.account.trim().toLowerCase())
+        );
       }
 
       const totalCount = needsPostProcessing ? formattedEntities.length : componentEntities.totalItems;

--- a/plugins/backstage-plugin-backend/src/service/router.test.ts
+++ b/plugins/backstage-plugin-backend/src/service/router.test.ts
@@ -2981,6 +2981,245 @@ describe('createRouter', () => {
         });
       });
 
+      describe('account filter', () => {
+        it('filters entities by account name', async () => {
+          mocked(fetch).mockReturnValue(
+            mockedResponse(200, {
+              services: [
+                {
+                  id: 'S3RV1CE1D',
+                  name: 'Test Service 1',
+                  description: 'Test Service Description 1',
+                  html_url: 'https://example.pagerduty.com/services/S3RV1CE1D',
+                  escalation_policy: {
+                    id: 'P0L1CY1D',
+                    name: 'Test Escalation Policy 1',
+                    html_url: 'https://example.pagerduty.com/escalation_policies/P0L1CY1D',
+                    type: 'escalation_policy_reference',
+                  },
+                  teams: [
+                    {
+                      id: 'T34M1D',
+                      name: 'Test Team 1',
+                    },
+                  ],
+                  account: 'production-account',
+                },
+                {
+                  id: 'SERVICE1',
+                  name: 'Test Service 2',
+                  description: 'Test Service Description 2',
+                  html_url: 'https://example.pagerduty.com/services/SERVICE1',
+                  escalation_policy: {
+                    id: 'P0L1CY1D',
+                    name: 'Test Escalation Policy 1',
+                    html_url: 'https://example.pagerduty.com/escalation_policies/P0L1CY1D',
+                    type: 'escalation_policy_reference',
+                  },
+                  teams: [
+                    {
+                      id: 'T34M1D',
+                      name: 'Test Team 1',
+                    },
+                  ],
+                  account: 'staging-account',
+                },
+              ],
+            }),
+          );
+
+          const response = await request(app)
+            .post('/mapping/entities')
+            .send({
+              offset: 0,
+              limit: 10,
+              filters: { account: 'production' },
+            });
+
+          expect(response.status).toEqual(200);
+          expect(response.body.entities).toHaveLength(1);
+          expect(response.body.entities[0].account).toEqual('production-account');
+        });
+
+        it('filters entities by account with case-insensitive matching', async () => {
+          mocked(fetch).mockReturnValue(
+            mockedResponse(200, {
+              services: [
+                {
+                  id: 'S3RV1CE1D',
+                  name: 'Test Service 1',
+                  description: 'Test Service Description 1',
+                  html_url: 'https://example.pagerduty.com/services/S3RV1CE1D',
+                  escalation_policy: {
+                    id: 'P0L1CY1D',
+                    name: 'Test Escalation Policy 1',
+                    html_url: 'https://example.pagerduty.com/escalation_policies/P0L1CY1D',
+                    type: 'escalation_policy_reference',
+                  },
+                  teams: [
+                    {
+                      id: 'T34M1D',
+                      name: 'Test Team 1',
+                    },
+                  ],
+                  account: 'Production-Account',
+                },
+              ],
+            }),
+          );
+
+          const response = await request(app)
+            .post('/mapping/entities')
+            .send({
+              offset: 0,
+              limit: 10,
+              filters: { account: 'PRODUCTION' },
+            });
+
+          expect(response.status).toEqual(200);
+          expect(response.body.entities).toHaveLength(1);
+          expect(response.body.entities[0].account).toEqual('Production-Account');
+        });
+
+        it('filters entities by partial account match', async () => {
+          mocked(fetch).mockReturnValue(
+            mockedResponse(200, {
+              services: [
+                {
+                  id: 'S3RV1CE1D',
+                  name: 'Test Service 1',
+                  description: 'Test Service Description 1',
+                  html_url: 'https://example.pagerduty.com/services/S3RV1CE1D',
+                  escalation_policy: {
+                    id: 'P0L1CY1D',
+                    name: 'Test Escalation Policy 1',
+                    html_url: 'https://example.pagerduty.com/escalation_policies/P0L1CY1D',
+                    type: 'escalation_policy_reference',
+                  },
+                  teams: [
+                    {
+                      id: 'T34M1D',
+                      name: 'Test Team 1',
+                    },
+                  ],
+                  account: 'my-production-account',
+                },
+                {
+                  id: 'SERVICE1',
+                  name: 'Test Service 2',
+                  description: 'Test Service Description 2',
+                  html_url: 'https://example.pagerduty.com/services/SERVICE1',
+                  escalation_policy: {
+                    id: 'P0L1CY1D',
+                    name: 'Test Escalation Policy 1',
+                    html_url: 'https://example.pagerduty.com/escalation_policies/P0L1CY1D',
+                    type: 'escalation_policy_reference',
+                  },
+                  teams: [
+                    {
+                      id: 'T34M1D',
+                      name: 'Test Team 1',
+                    },
+                  ],
+                  account: 'staging-account',
+                },
+              ],
+            }),
+          );
+
+          const response = await request(app)
+            .post('/mapping/entities')
+            .send({
+              offset: 0,
+              limit: 10,
+              filters: { account: 'prod' },
+            });
+
+          expect(response.status).toEqual(200);
+          expect(response.body.entities).toHaveLength(1);
+          expect(response.body.entities[0].account).toEqual('my-production-account');
+        });
+
+        it('handles account filter with whitespace', async () => {
+          mocked(fetch).mockReturnValue(
+            mockedResponse(200, {
+              services: [
+                {
+                  id: 'S3RV1CE1D',
+                  name: 'Test Service 1',
+                  description: 'Test Service Description 1',
+                  html_url: 'https://example.pagerduty.com/services/S3RV1CE1D',
+                  escalation_policy: {
+                    id: 'P0L1CY1D',
+                    name: 'Test Escalation Policy 1',
+                    html_url: 'https://example.pagerduty.com/escalation_policies/P0L1CY1D',
+                    type: 'escalation_policy_reference',
+                  },
+                  teams: [
+                    {
+                      id: 'T34M1D',
+                      name: 'Test Team 1',
+                    },
+                  ],
+                  account: 'production-account',
+                },
+              ],
+            }),
+          );
+
+          const response = await request(app)
+            .post('/mapping/entities')
+            .send({
+              offset: 0,
+              limit: 10,
+              filters: { account: '  production  ' },
+            });
+
+          expect(response.status).toEqual(200);
+          expect(response.body.entities).toHaveLength(1);
+          expect(response.body.entities[0].account).toEqual('production-account');
+        });
+
+        it('returns empty array when no entities match account filter', async () => {
+          mocked(fetch).mockReturnValue(
+            mockedResponse(200, {
+              services: [
+                {
+                  id: 'S3RV1CE1D',
+                  name: 'Test Service 1',
+                  description: 'Test Service Description 1',
+                  html_url: 'https://example.pagerduty.com/services/S3RV1CE1D',
+                  escalation_policy: {
+                    id: 'P0L1CY1D',
+                    name: 'Test Escalation Policy 1',
+                    html_url: 'https://example.pagerduty.com/escalation_policies/P0L1CY1D',
+                    type: 'escalation_policy_reference',
+                  },
+                  teams: [
+                    {
+                      id: 'T34M1D',
+                      name: 'Test Team 1',
+                    },
+                  ],
+                  account: 'production-account',
+                },
+              ],
+            }),
+          );
+
+          const response = await request(app)
+            .post('/mapping/entities')
+            .send({
+              offset: 0,
+              limit: 10,
+              filters: { account: 'nonexistent' },
+            });
+
+          expect(response.status).toEqual(200);
+          expect(response.body.entities).toEqual([]);
+        });
+      });
+
       // TODO: Test the rest of the filters when InMemoryCatalogApi supports fullTextSearch (https://pagerduty.atlassian.net/browse/DEVECO-623)
     });
 
@@ -2996,15 +3235,13 @@ describe('createRouter', () => {
         });
       });
 
-      it('returns 400 if mappings array is empty', async () => {
+      it('returns 200 if mappings array is empty', async () => {
         const response = await request(app)
           .post('/mapping/entities/bulk')
           .send({ mappings: [] });
 
-        expect(response.status).toEqual(400);
-        expect(response.body).toEqual({
-          error: "Bad Request: 'mappings' array cannot be empty",
-        });
+        expect(response.status).toEqual(200);
+        expect(response.body.successCount).toEqual(0);
       });
 
       it('returns error for mappings without serviceId', async () => {

--- a/plugins/backstage-plugin-backend/src/service/router.ts
+++ b/plugins/backstage-plugin-backend/src/service/router.ts
@@ -23,7 +23,6 @@ import {
   getServiceRelationshipsById,
   addServiceRelationsToService,
   removeServiceRelationsFromService,
-  getServicesByIds,
 } from '../apis/pagerduty';
 import { loadBothSources, ServiceLoadError } from '../services/dataLoader';
 import {
@@ -53,11 +52,10 @@ import {
 } from '../db/PagerDutyBackendDatabase';
 import * as express from 'express';
 import Router from 'express-promise-router';
-import type {
-  CatalogApi,
-  GetEntitiesByRefsResponse,
-  GetEntitiesResponse,
-} from '@backstage/catalog-client';
+import type { CatalogApi, GetEntitiesResponse } from '@backstage/catalog-client';
+
+import * as MappingsController from '../controllers/mappings-controller';
+import * as CatalogEntityUtils from '../utils/catalog-entity';
 
 export interface RouterOptions {
   logger: LoggerService;
@@ -73,48 +71,6 @@ export type Annotations = {
   'pagerduty.com/service-id': string;
   'pagerduty.com/account': string;
 };
-
-export async function createComponentEntitiesReferenceDict({
-  items: componentEntities,
-}: GetEntitiesResponse | GetEntitiesByRefsResponse): Promise<
-  Record<string, { ref: string; name: string }>
-> {
-  const componentEntitiesDict: Record<string, { ref: string; name: string }> =
-    {};
-
-  await Promise.all(
-    componentEntities.map(async entity => {
-      const serviceId =
-        entity?.metadata.annotations?.['pagerduty.com/service-id'];
-      const integrationKey =
-        entity?.metadata.annotations?.['pagerduty.com/integration-key'];
-      const account = entity?.metadata.annotations?.['pagerduty.com/account'];
-
-      if (serviceId !== undefined && serviceId !== '') {
-        componentEntitiesDict[serviceId] = {
-          ref: `${entity?.kind}:${entity?.metadata.namespace}/${entity?.metadata.name}`.toLowerCase(),
-          name: entity?.metadata.name ?? '',
-        };
-      } else if (integrationKey !== undefined && integrationKey !== '') {
-        // get service id from integration key, we ignore errors here since we're focused
-        // only on building a mapping between valid service IDs and the corresponding Backstage entity
-        const service = await getServiceByIntegrationKey(
-          integrationKey,
-          account,
-        ).catch(() => undefined);
-
-        if (service !== undefined) {
-          componentEntitiesDict[service.id] = {
-            ref: `${entity?.kind}:${entity?.metadata.namespace}/${entity?.metadata.name}`.toLowerCase(),
-            name: entity?.metadata.name ?? '',
-          };
-        }
-      }
-    }),
-  );
-
-  return componentEntitiesDict;
-}
 
 export async function buildEntityMappingsResponse(
   entityMappings: RawDbEntityResultRow[],
@@ -804,7 +760,7 @@ export async function createRouter(
       const componentEntitiesDict: Record<
         string,
         { ref: string; name: string }
-      > = await createComponentEntitiesReferenceDict(componentEntities);
+      > = await CatalogEntityUtils.createComponentEntitiesReferenceDict(componentEntities);
 
       // Get all services from PagerDuty
       const pagerDutyServices = await getAllServices();
@@ -829,185 +785,7 @@ export async function createRouter(
   });
 
   // POST /mapping/entities - returns mappings for paginated entities with search capability
-  router.post('/mapping/entities', async (request, response) => {
-    try {
-      const {
-        offset = 0,
-        limit = 10,
-        search,
-        searchFields = ['metadata.name', 'spec.owner'],
-      } = request.body;
-
-      if (
-        typeof offset !== 'number' ||
-        typeof limit !== 'number' ||
-        offset < 0 ||
-        limit <= 0
-      ) {
-        response.status(400).json({
-          errors: ["Bad Request: 'offset' and 'limit' must be valid numbers"],
-        });
-        return;
-      }
-
-      const queryOptions: {
-        filter: { kind: string }[];
-        limit: number;
-        offset: number;
-        fullTextFilter?: { term: string; fields: string[] };
-      } = {
-        filter: [{ kind: 'Component' }],
-        limit,
-        offset,
-      };
-
-      if (search && search.trim() !== '') {
-        queryOptions.fullTextFilter = {
-          term: search,
-          fields: searchFields,
-        };
-      }
-
-      const componentEntities = await catalogApi!.queryEntities(queryOptions);
-      const entityMappings = await store.getAllEntityMappings();
-      const componentEntitiesDict: Record<
-        string,
-        { ref: string; name: string }
-      > = await createComponentEntitiesReferenceDict(componentEntities);
-
-      // Get the mappings which are visible in the table at the specific pagination
-      const relevantMappings = entityMappings.filter(mapping => {
-        return componentEntities.items.some(entity => {
-          const entityRef =
-            `${entity?.kind}:${entity?.metadata.namespace}/${entity?.metadata.name}`.toLowerCase();
-          const integrationKey =
-            entity?.metadata.annotations?.['pagerduty.com/integration-key'];
-          return (
-            mapping.entityRef === entityRef ||
-            mapping.integrationKey === integrationKey
-          );
-        });
-      });
-
-      const pagerDutyServiceIds = relevantMappings
-        .map(e => e.serviceId)
-        .filter(Boolean);
-      // Only do requests for PagerDuty services which are visible by the pagination
-      const pagerDutyServices = await getServicesByIds(pagerDutyServiceIds);
-
-      const maps = await buildEntityMappingsResponse(
-        entityMappings,
-        componentEntitiesDict,
-        componentEntities,
-        pagerDutyServices,
-      );
-
-      const formattedEntities = await Promise.all(
-        componentEntities.items.map(async entity => {
-          const annotations = {
-            'pagerduty.com/integration-key':
-              entity.metadata?.annotations?.['pagerduty.com/integration-key'] ??
-              '',
-            'pagerduty.com/service-id':
-              entity.metadata?.annotations?.['pagerduty.com/service-id'] ?? '',
-          };
-
-          const formattedEntity = {
-            name: entity.metadata?.name,
-            id: entity.metadata?.uid ?? '',
-            namespace: entity.metadata?.namespace ?? '',
-            type: entity.kind ?? '',
-            system: entity.spec?.system
-              ? JSON.stringify(entity.spec?.system)
-              : '',
-            owner: entity.spec?.owner ? JSON.stringify(entity.spec?.owner) : '',
-            lifecycle: entity.spec?.lifecycle
-              ? JSON.stringify(entity.spec?.lifecycle)
-              : '',
-            annotations,
-            status: 'NotMapped' as
-              | 'NotMapped'
-              | 'InSync'
-              | 'OutOfSync'
-              | 'ErrorWhenFetchingService',
-            serviceName: '',
-            serviceUrl: '',
-            team: '',
-            escalationPolicy: '',
-            account: '',
-          };
-
-          // Try to find a service by service ID or integration key
-          let service = null;
-          let isServiceError = null;
-          if (annotations['pagerduty.com/service-id']) {
-            const serviceId = annotations['pagerduty.com/service-id'];
-            service = pagerDutyServices.find(s => s.id === serviceId);
-          } else if (annotations['pagerduty.com/integration-key']) {
-            const integrationKey = annotations['pagerduty.com/integration-key'];
-            const account =
-              entity.metadata?.annotations?.['pagerduty.com/account'] || '';
-            try {
-              service = await getServiceByIntegrationKey(
-                integrationKey,
-                account,
-              );
-            } catch (e) {
-              if (e instanceof HttpError && e.status !== 404) {
-                isServiceError = true;
-              }
-            }
-          }
-          const entityRef =
-            `${entity.kind}:${entity.metadata.namespace}/${entity.metadata.name}`.toLowerCase();
-          const entityMapping = maps.mappings.find(
-            e =>
-              e.entityRef === entityRef ||
-              (e.integrationKey &&
-                e.integrationKey ===
-                  annotations['pagerduty.com/integration-key']) ||
-              (e.serviceId &&
-                e.serviceId === annotations['pagerduty.com/service-id']),
-          );
-
-          if (service) {
-            formattedEntity.serviceName = service.name;
-            formattedEntity.serviceUrl = service.html_url;
-            formattedEntity.team = service.teams?.[0]?.name ?? '';
-            formattedEntity.escalationPolicy =
-              service.escalation_policy?.name ?? '';
-            formattedEntity.account = service.account || '';
-            if (entityMapping) {
-              const expectedEntityRef = componentEntitiesDict[service.id]?.ref;
-              if (
-                expectedEntityRef &&
-                expectedEntityRef === entityMapping.entityRef
-              ) {
-                formattedEntity.status = entityMapping.status || 'NotMapped';
-              } else {
-                formattedEntity.status = 'NotMapped';
-              }
-            }
-          } else if (isServiceError) {
-            formattedEntity.status = 'ErrorWhenFetchingService';
-          }
-
-          return formattedEntity;
-        }),
-      );
-
-      response.json({
-        entities: formattedEntities,
-        totalCount: componentEntities.totalItems,
-      });
-    } catch (error) {
-      if (error instanceof HttpError) {
-        response.status(error.status).json({
-          errors: [`${error.message}`],
-        });
-      }
-    }
-  });
+  router.post('/mapping/entities', MappingsController.getMappingEntities(store, catalogApi));
 
   // GET /mapping/entity
   router.get(

--- a/plugins/backstage-plugin-backend/src/service/router.ts
+++ b/plugins/backstage-plugin-backend/src/service/router.ts
@@ -252,6 +252,10 @@ export async function createRouter(
     auth = createLegacyAuthAdapters(options).auth;
   }
 
+  if (!catalogApi) {
+    throw new Error('Catalog API is required to start the PagerDuty plugin backend');
+  }
+
   // Get authentication Config
   await loadAuthConfig(config, logger);
 
@@ -784,7 +788,6 @@ export async function createRouter(
     }
   });
 
-  // POST /mapping/entities - returns mappings for paginated entities with search capability
   router.post('/mapping/entities', MappingsController.getMappingEntities(store, catalogApi));
 
   // GET /mapping/entity

--- a/plugins/backstage-plugin-backend/src/services/pagerduty/index.ts
+++ b/plugins/backstage-plugin-backend/src/services/pagerduty/index.ts
@@ -1,0 +1,12 @@
+import { getAllServices } from "../../apis/pagerduty";
+
+export async function getServicesIdsByPartialName(partialName: string): Promise<string[]> {
+  const pagerdutyServices = await getAllServices();
+  const matchingServices = pagerdutyServices.filter(service =>
+    service.name
+      .toLowerCase()
+      .includes(partialName.toLowerCase()),
+  );
+
+  return matchingServices.map(service => service.id);
+}

--- a/plugins/backstage-plugin-backend/src/services/pagerduty/index.ts
+++ b/plugins/backstage-plugin-backend/src/services/pagerduty/index.ts
@@ -1,12 +1,7 @@
-import { getAllServices } from "../../apis/pagerduty";
+import { getServicesByPartialName } from "../../apis/pagerduty";
 
 export async function getServicesIdsByPartialName(partialName: string): Promise<string[]> {
-  const pagerdutyServices = await getAllServices();
-  const matchingServices = pagerdutyServices.filter(service =>
-    service.name
-      .toLowerCase()
-      .includes(partialName.toLowerCase()),
-  );
+  const pagerdutyServices = await getServicesByPartialName(partialName);
 
-  return matchingServices.map(service => service.id);
+  return pagerdutyServices.map(service => service.id);
 }

--- a/plugins/backstage-plugin-backend/src/utils/catalog-entity.ts
+++ b/plugins/backstage-plugin-backend/src/utils/catalog-entity.ts
@@ -1,0 +1,64 @@
+import { GetEntitiesByRefsResponse, GetEntitiesResponse } from "@backstage/catalog-client";
+import { getServiceByIntegrationKey } from "../apis/pagerduty";
+
+// simplification of the CatalogEntity type - this type is not publicly exposed by the catalog-client package.
+interface CatalogEntity {
+  kind: string;
+  metadata: {
+    namespace?: string;
+    name: string;
+    annotations?: {
+      [key: string]: string;
+    };
+  };  
+}
+
+export function entityRef(entity: CatalogEntity): string {
+  return `${entity.kind}:${entity.metadata.namespace ?? 'default'}/${entity.metadata.name}`.toLowerCase();
+}
+
+export function getPagerDutyIntegrationKey(entity: CatalogEntity): string | undefined {
+  return entity.metadata.annotations?.['pagerduty.com/integration-key'];
+}
+
+export function getPagerDutyServiceId(entity: CatalogEntity): string | undefined {
+  return entity.metadata.annotations?.['pagerduty.com/service-id'];
+}
+
+export function getPagerDutyAccount(entity: CatalogEntity): string | undefined {
+  return entity.metadata.annotations?.['pagerduty.com/account'];
+}
+
+export async function createComponentEntitiesReferenceDict({
+  items: componentEntities,
+}: GetEntitiesResponse | GetEntitiesByRefsResponse): Promise<Record<string, { ref: string; name: string }>> {
+  const componentEntitiesDict: Record<string, { ref: string; name: string }> = {};
+
+  await Promise.all(
+    componentEntities.map(async entity => {
+      const serviceId = getPagerDutyServiceId(entity!);
+      const integrationKey = getPagerDutyIntegrationKey(entity!);
+      const account = getPagerDutyAccount(entity!);
+
+      if (serviceId) {
+        componentEntitiesDict[serviceId] = {
+          ref: entityRef(entity!),
+          name: entity?.metadata.name ?? '',
+        };
+      } else if (integrationKey) {
+        // get service id from integration key, we ignore errors here since we're focused
+        // only on building a mapping between valid service IDs and the corresponding Backstage entity
+        const service = await getServiceByIntegrationKey(integrationKey, account,).catch(() => undefined);
+
+        if (service) {
+          componentEntitiesDict[service.id] = {
+            ref: entityRef(entity!).toLowerCase(),
+            name: entity?.metadata.name ?? '',
+          };
+        }
+      }
+    }),
+  );
+
+  return componentEntitiesDict;
+}

--- a/plugins/backstage-plugin-common/src/types.ts
+++ b/plugins/backstage-plugin-common/src/types.ts
@@ -304,7 +304,7 @@ export type FormattedBackstageEntity = {
   serviceUrl?: string;
   team?: string;
   escalationPolicy?: string;
-  status?: 'NotMapped' | 'InSync' | 'OutOfSync';
+  status?: 'NotMapped' | 'InSync' | 'OutOfSync' | 'ErrorWhenFetchingService';
   account?: string;
 };
 

--- a/plugins/backstage-plugin/dev/mockPagerDutyApi.ts
+++ b/plugins/backstage-plugin/dev/mockPagerDutyApi.ts
@@ -108,8 +108,12 @@ export const mockPagerDutyApi: PagerDutyApi = {
   async getEntityMappingsWithPagination(options: {
     offset: number;
     limit: number;
-    search?: string;
     searchFields?: string[];
+    filters?: {
+      name?: string;
+      serviceName?: string;
+      status?: string;
+    };
   }): Promise<PagerDutyEnhancedEntityMappingsResponse> {
     const mockEntities: FormattedBackstageEntity[] = [
       {
@@ -167,8 +171,8 @@ export const mockPagerDutyApi: PagerDutyApi = {
     ];
 
     let filteredEntities = [...mockEntities];
-    if (options.search && options.search.trim() !== '') {
-      const searchTerm = options.search.toLowerCase();
+    if (options.filters?.name && options.filters.name.trim() !== '') {
+      const searchTerm = options.filters.name.toLowerCase();
       filteredEntities = mockEntities.filter(
         entity =>
           entity.name.toLowerCase().includes(searchTerm) ||

--- a/plugins/backstage-plugin/dev/mockPagerDutyApi.ts
+++ b/plugins/backstage-plugin/dev/mockPagerDutyApi.ts
@@ -113,6 +113,7 @@ export const mockPagerDutyApi: PagerDutyApi = {
       name?: string;
       serviceName?: string;
       status?: string;
+      teamName?: string;
     };
   }): Promise<PagerDutyEnhancedEntityMappingsResponse> {
     const mockEntities: FormattedBackstageEntity[] = [
@@ -171,12 +172,16 @@ export const mockPagerDutyApi: PagerDutyApi = {
     ];
 
     let filteredEntities = [...mockEntities];
-    if (options.filters?.name && options.filters.name.trim() !== '') {
-      const searchTerm = options.filters.name.toLowerCase();
+
+    if (options.filters?.name?.trim()) {
       filteredEntities = mockEntities.filter(
-        entity =>
-          entity.name.toLowerCase().includes(searchTerm) ||
-          entity.owner.toLowerCase().includes(searchTerm),
+        entity => entity.name.toLowerCase().includes(options.filters!.name!.toLowerCase())
+      );
+    }
+
+    if (options.filters?.teamName?.trim()) {
+      filteredEntities = mockEntities.filter(
+        entity => entity.owner.toLowerCase().includes(options.filters!.teamName!.toLowerCase())
       );
     }
 

--- a/plugins/backstage-plugin/src/api/client.ts
+++ b/plugins/backstage-plugin/src/api/client.ts
@@ -148,6 +148,7 @@ export class PagerDutyClient implements PagerDutyApi {
       name?: string;
       serviceName?: string;
       status?: string;
+      teamName?: string;
     };
   }): Promise<PagerDutyEnhancedEntityMappingsResponse> {
     const url = `${await this.config.discoveryApi.getBaseUrl(

--- a/plugins/backstage-plugin/src/api/client.ts
+++ b/plugins/backstage-plugin/src/api/client.ts
@@ -144,6 +144,11 @@ export class PagerDutyClient implements PagerDutyApi {
     limit: number;
     search?: string;
     searchFields?: string[];
+    filters?: {
+      name?: string;
+      serviceName?: string;
+      status?: string;
+    };
   }): Promise<PagerDutyEnhancedEntityMappingsResponse> {
     const url = `${await this.config.discoveryApi.getBaseUrl(
       'pagerduty',
@@ -154,6 +159,7 @@ export class PagerDutyClient implements PagerDutyApi {
       limit: options.limit,
       search: options.search,
       searchFields: options.searchFields || ['metadata.name', 'spec.owner'],
+      filters: options.filters || {},
     });
 
     const requestOptions = {

--- a/plugins/backstage-plugin/src/api/client.ts
+++ b/plugins/backstage-plugin/src/api/client.ts
@@ -149,6 +149,7 @@ export class PagerDutyClient implements PagerDutyApi {
       serviceName?: string;
       status?: string;
       teamName?: string;
+      account?: string;
     };
   }): Promise<PagerDutyEnhancedEntityMappingsResponse> {
     const url = `${await this.config.discoveryApi.getBaseUrl(

--- a/plugins/backstage-plugin/src/api/client.ts
+++ b/plugins/backstage-plugin/src/api/client.ts
@@ -142,8 +142,6 @@ export class PagerDutyClient implements PagerDutyApi {
   async getEntityMappingsWithPagination(options: {
     offset: number;
     limit: number;
-    search?: string;
-    searchFields?: string[];
     filters?: {
       name?: string;
       serviceName?: string;
@@ -151,6 +149,7 @@ export class PagerDutyClient implements PagerDutyApi {
       teamName?: string;
       account?: string;
     };
+    sort?: { column: string; direction: 'ascending' | 'descending' };
   }): Promise<PagerDutyEnhancedEntityMappingsResponse> {
     const url = `${await this.config.discoveryApi.getBaseUrl(
       'pagerduty',
@@ -159,9 +158,8 @@ export class PagerDutyClient implements PagerDutyApi {
     const body = JSON.stringify({
       offset: options.offset,
       limit: options.limit,
-      search: options.search,
-      searchFields: options.searchFields || ['metadata.name', 'spec.owner'],
       filters: options.filters || {},
+      sort: options.sort,
     });
 
     const requestOptions = {

--- a/plugins/backstage-plugin/src/api/types.ts
+++ b/plugins/backstage-plugin/src/api/types.ts
@@ -73,12 +73,14 @@ export interface PagerDutyApi {
   getEntityMappingsWithPagination(options: {
     offset: number;
     limit: number;
-    searchFields?: string[];
     filters?: {
       name?: string;
       serviceName?: string;
       status?: string;
+      teamName?: string;
+      account?: string;
     };
+    sort?: { column: string; direction: 'ascending' | 'descending' };
   }): Promise<PagerDutyEnhancedEntityMappingsResponse>;
 
   /**

--- a/plugins/backstage-plugin/src/api/types.ts
+++ b/plugins/backstage-plugin/src/api/types.ts
@@ -73,8 +73,12 @@ export interface PagerDutyApi {
   getEntityMappingsWithPagination(options: {
     offset: number;
     limit: number;
-    search?: string;
     searchFields?: string[];
+    filters?: {
+      name?: string;
+      serviceName?: string;
+      status?: string;
+    };
   }): Promise<PagerDutyEnhancedEntityMappingsResponse>;
 
   /**

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/FilterRow.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/FilterRow.tsx
@@ -1,0 +1,63 @@
+import { Row, Cell, SearchField, Select } from '@backstage/ui';
+
+type FilterableFields = 'name' | 'serviceName' | 'status';
+
+interface FilterRowProps {
+  filters: {
+    name: string;
+    serviceName: string;
+    status: string;
+  };
+  onFilterChange: (key: FilterableFields, value: string) => void;
+}
+
+const statusOptions = [
+  { value: '', label: 'All' },
+  { value: 'InSync', label: 'In Sync' },
+  { value: 'OutOfSync', label: 'Out of Sync' },
+  { value: 'NotMapped', label: 'Not Mapped' },
+  { value: 'ErrorWhenFetchingService', label: 'Error' },
+];
+
+export function FilterRow({ filters, onFilterChange }: FilterRowProps) {
+  return (
+    <Row>
+      <Cell>
+        <SearchField
+          size="small"
+          placeholder="Filter by name"
+          value={filters.name}
+          onChange={value => onFilterChange('name', value)}
+        />
+      </Cell>
+
+      <Cell>
+        <div />
+      </Cell>
+      
+      <Cell>
+        <SearchField
+          size="small"
+          placeholder="Filter by service"
+          value={filters.serviceName}
+          onChange={value => onFilterChange('serviceName', value)}
+        />
+      </Cell>
+      
+      <Cell>
+        <Select
+          selectionMode="single"
+          size="small"
+          value={filters.status}
+          onChange={value => onFilterChange('status', value?.toString() || '')}
+          placeholder="All statuses"
+          options={statusOptions}
+        />
+      </Cell>
+      
+      <Cell>
+        <div />
+      </Cell>
+    </Row>
+  );
+}

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/FilterRow.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/FilterRow.tsx
@@ -1,12 +1,13 @@
 import { Row, Cell, SearchField, Select } from '@backstage/ui';
 
-type FilterableFields = 'name' | 'serviceName' | 'status';
+type FilterableFields = 'name' | 'serviceName' | 'status' | 'teamName';
 
 interface FilterRowProps {
   filters: {
     name: string;
     serviceName: string;
     status: string;
+    teamName: string;
   };
   onFilterChange: (key: FilterableFields, value: string) => void;
 }
@@ -32,7 +33,12 @@ export function FilterRow({ filters, onFilterChange }: FilterRowProps) {
       </Cell>
 
       <Cell>
-        <div />
+        <SearchField
+          size="small"
+          placeholder="Filter by team"
+          value={filters.teamName}
+          onChange={value => onFilterChange('teamName', value)}
+        />
       </Cell>
       
       <Cell>
@@ -55,6 +61,12 @@ export function FilterRow({ filters, onFilterChange }: FilterRowProps) {
         />
       </Cell>
       
+      <Cell>
+        <div />
+      </Cell>
+      <Cell>
+        <div />
+      </Cell>
       <Cell>
         <div />
       </Cell>

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/FilterRow.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/FilterRow.tsx
@@ -1,6 +1,6 @@
 import { Row, Cell, SearchField, Select } from '@backstage/ui';
 
-type FilterableFields = 'name' | 'serviceName' | 'status' | 'teamName';
+type FilterableFields = 'name' | 'serviceName' | 'status' | 'teamName' | 'account';
 
 interface FilterRowProps {
   filters: {
@@ -8,12 +8,13 @@ interface FilterRowProps {
     serviceName: string;
     status: string;
     teamName: string;
+    account: string;
   };
   onFilterChange: (key: FilterableFields, value: string) => void;
 }
 
 const statusOptions = [
-  { value: '', label: 'All' },
+  { value: '', label: 'All Statuses' },
   { value: 'InSync', label: 'In Sync' },
   { value: 'OutOfSync', label: 'Out of Sync' },
   { value: 'NotMapped', label: 'Not Mapped' },
@@ -60,9 +61,14 @@ export function FilterRow({ filters, onFilterChange }: FilterRowProps) {
           options={statusOptions}
         />
       </Cell>
-      
+
       <Cell>
-        <div />
+        <SearchField
+          size="small"
+          placeholder="Filter by account"
+          value={filters.account}
+          onChange={value => onFilterChange('account', value)}
+        />
       </Cell>
       <Cell>
         <div />

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/MappingsTable.test.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/MappingsTable.test.tsx
@@ -215,8 +215,8 @@ describe('MappingsTable', () => {
       expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith({
         offset: 0,
         limit: 10,
-        searchFields: ['metadata.name', 'spec.owner'],
         filters: { name: 'my-component', serviceName: '', status: '', teamName: '', account: '' },
+        sort: undefined
       });
     });
 
@@ -255,8 +255,8 @@ describe('MappingsTable', () => {
     expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith({
       offset: 0,
       limit: 10,
-      searchFields: ['metadata.name', 'spec.owner'],
       filters: { name: '', serviceName: '', status: '', teamName: '', account: '' },
+      sort: undefined
     });
 
     expect(screen.getByText('1 - 10 of 25')).toBeInTheDocument();
@@ -268,8 +268,8 @@ describe('MappingsTable', () => {
       expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith({
         offset: 10,
         limit: 10,
-        searchFields: ['metadata.name', 'spec.owner'],
         filters: { name: '', serviceName: '', status: '', teamName: '', account: '' },
+        sort: undefined
       });
     });
 
@@ -280,8 +280,8 @@ describe('MappingsTable', () => {
       expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith({
         offset: 0,
         limit: 10,
-        searchFields: ['metadata.name', 'spec.owner'],
         filters: { name: '', serviceName: '', status: '', teamName: '', account: '' },
+        sort: undefined
       });
     });
   });
@@ -484,5 +484,320 @@ describe('MappingsTable', () => {
     });
 
     jest.useRealTimers();
+  });
+
+  describe('sorting', () => {
+    it('calls API with sort parameter when Name column header is clicked', async () => {
+      mockGetEntityMappingsWithPagination.mockResolvedValue({
+        entities: [],
+        totalCount: 0,
+      });
+
+      await renderInTestApp(
+        <ApiProvider apis={apis}>
+          <QueryClientProvider client={queryClient}>
+            <MappingsTable />
+          </QueryClientProvider>
+        </ApiProvider>,
+      );
+
+      const nameColumnHeader = screen.getByText('Name');
+      fireEvent.click(nameColumnHeader);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sort: { column: 'name', direction: 'ascending' },
+          }),
+        );
+      });
+    });
+
+    it('toggles sort direction when clicking the same column header twice', async () => {
+      mockGetEntityMappingsWithPagination.mockResolvedValue({
+        entities: [],
+        totalCount: 0,
+      });
+
+      await renderInTestApp(
+        <ApiProvider apis={apis}>
+          <QueryClientProvider client={queryClient}>
+            <MappingsTable />
+          </QueryClientProvider>
+        </ApiProvider>,
+      );
+
+      const nameColumnHeader = screen.getByText('Name');
+
+      // First click - ascending
+      fireEvent.click(nameColumnHeader);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sort: { column: 'name', direction: 'ascending' },
+          }),
+        );
+      });
+
+      // Second click - descending
+      fireEvent.click(nameColumnHeader);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sort: { column: 'name', direction: 'descending' },
+          }),
+        );
+      });
+    });
+
+    it('calls API with sort parameter when Team column header is clicked', async () => {
+      mockGetEntityMappingsWithPagination.mockResolvedValue({
+        entities: [],
+        totalCount: 0,
+      });
+
+      await renderInTestApp(
+        <ApiProvider apis={apis}>
+          <QueryClientProvider client={queryClient}>
+            <MappingsTable />
+          </QueryClientProvider>
+        </ApiProvider>,
+      );
+
+      const teamColumnHeader = screen.getByText('Team');
+      fireEvent.click(teamColumnHeader);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sort: { column: 'team', direction: 'ascending' },
+          }),
+        );
+      });
+    });
+
+    it('calls API with sort parameter when PagerDuty service column header is clicked', async () => {
+      mockGetEntityMappingsWithPagination.mockResolvedValue({
+        entities: [],
+        totalCount: 0,
+      });
+
+      await renderInTestApp(
+        <ApiProvider apis={apis}>
+          <QueryClientProvider client={queryClient}>
+            <MappingsTable />
+          </QueryClientProvider>
+        </ApiProvider>,
+      );
+
+      const serviceColumnHeader = screen.getByText('PagerDuty service');
+      fireEvent.click(serviceColumnHeader);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sort: { column: 'serviceName', direction: 'ascending' },
+          }),
+        );
+      });
+    });
+
+    it('calls API with sort parameter when Status column header is clicked', async () => {
+      mockGetEntityMappingsWithPagination.mockResolvedValue({
+        entities: [],
+        totalCount: 0,
+      });
+
+      await renderInTestApp(
+        <ApiProvider apis={apis}>
+          <QueryClientProvider client={queryClient}>
+            <MappingsTable />
+          </QueryClientProvider>
+        </ApiProvider>,
+      );
+
+      const statusColumnHeader = screen.getByText('Status');
+      fireEvent.click(statusColumnHeader);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sort: { column: 'status', direction: 'ascending' },
+          }),
+        );
+      });
+    });
+
+    it('calls API with sort parameter when Account column header is clicked', async () => {
+      mockGetEntityMappingsWithPagination.mockResolvedValue({
+        entities: [],
+        totalCount: 0,
+      });
+
+      await renderInTestApp(
+        <ApiProvider apis={apis}>
+          <QueryClientProvider client={queryClient}>
+            <MappingsTable />
+          </QueryClientProvider>
+        </ApiProvider>,
+      );
+
+      const accountColumnHeader = screen.getByText('Account');
+      fireEvent.click(accountColumnHeader);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sort: { column: 'account', direction: 'ascending' },
+          }),
+        );
+      });
+    });
+
+    it('switches sort column when clicking different column headers', async () => {
+      mockGetEntityMappingsWithPagination.mockResolvedValue({
+        entities: [],
+        totalCount: 0,
+      });
+
+      await renderInTestApp(
+        <ApiProvider apis={apis}>
+          <QueryClientProvider client={queryClient}>
+            <MappingsTable />
+          </QueryClientProvider>
+        </ApiProvider>,
+      );
+
+      // Sort by name
+      const nameColumnHeader = screen.getByText('Name');
+      fireEvent.click(nameColumnHeader);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sort: { column: 'name', direction: 'ascending' },
+          }),
+        );
+      });
+
+      // Switch to sort by team
+      const teamColumnHeader = screen.getByText('Team');
+      fireEvent.click(teamColumnHeader);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sort: { column: 'team', direction: 'ascending' },
+          }),
+        );
+      });
+    });
+
+    it('resets offset to 0 when sort changes', async () => {
+      const mockEntities = Array.from({ length: 10 }, (_, i) => ({
+        id: `entity-${i}`,
+        name: `service-${i}`,
+        namespace: 'default',
+        type: 'service',
+        system: 'core',
+        owner: `team-${i}`,
+        lifecycle: 'production',
+        annotations: {
+          'pagerduty.com/integration-key': `key-${i}`,
+          'pagerduty.com/service-id': `PD${i}`,
+        },
+        status: 'InSync' as const,
+      }));
+
+      mockGetEntityMappingsWithPagination.mockResolvedValue({
+        entities: mockEntities,
+        totalCount: 25,
+      });
+
+      await renderInTestApp(
+        <ApiProvider apis={apis}>
+          <QueryClientProvider client={queryClient}>
+            <MappingsTable />
+          </QueryClientProvider>
+        </ApiProvider>,
+      );
+
+      // Navigate to second page
+      const nextButton = screen.getByLabelText('Next');
+      fireEvent.click(nextButton);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            offset: 10,
+          }),
+        );
+      });
+
+      // Click sort column - should reset to offset 0
+      const nameColumnHeader = screen.getByText('Name');
+      fireEvent.click(nameColumnHeader);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            offset: 0,
+            sort: { column: 'name', direction: 'ascending' },
+          }),
+        );
+      });
+    });
+
+    it('maintains sort when filters are applied', async () => {
+      jest.useFakeTimers();
+      mockGetEntityMappingsWithPagination.mockResolvedValue({
+        entities: [],
+        totalCount: 0,
+      });
+
+      await renderInTestApp(
+        <ApiProvider apis={apis}>
+          <QueryClientProvider client={queryClient}>
+            <MappingsTable />
+          </QueryClientProvider>
+        </ApiProvider>,
+      );
+
+      // Apply sort first
+      const nameColumnHeader = screen.getByText('Name');
+      fireEvent.click(nameColumnHeader);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sort: { column: 'name', direction: 'ascending' },
+          }),
+        );
+      });
+
+      // Apply filter
+      const filterButton = screen.getByRole('button', { name: 'Toggle filters' });
+      fireEvent.click(filterButton);
+
+      const nameFilter = screen.getByPlaceholderText('Filter by name');
+      fireEvent.change(nameFilter, { target: { value: 'test-service' } });
+
+      jest.advanceTimersByTime(500);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            filters: expect.objectContaining({
+              name: 'test-service',
+            }),
+            sort: { column: 'name', direction: 'ascending' },
+          }),
+        );
+      });
+
+      jest.useRealTimers();
+    });
   });
 });

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/MappingsTable.test.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/MappingsTable.test.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line @backstage/no-undeclared-imports
-import { act, fireEvent, screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { renderInTestApp, TestApiRegistry } from '@backstage/test-utils';
 import { pagerDutyApiRef } from '../../../api';
 import MappingsTable from './MappingsTable';
@@ -195,13 +195,11 @@ describe('MappingsTable', () => {
       </ApiProvider>,
     );
 
-    const searchInput = screen.getByPlaceholderText(
-      'Search for components or teams',
-    );
+    const filterButton = screen.getByRole('button', { name: 'Toggle filters' });
+    fireEvent.click(filterButton);
 
-    await act(async () => {
-      fireEvent.change(searchInput, { target: { value: 'my-component' } });
-    });
+    const serviceFilter = screen.getByPlaceholderText('Filter by name');
+    fireEvent.change(serviceFilter, { target: { value: 'my-component' } });
 
     jest.advanceTimersByTime(500);
 
@@ -209,8 +207,8 @@ describe('MappingsTable', () => {
       expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith({
         offset: 0,
         limit: 10,
-        search: 'my-component',
         searchFields: ['metadata.name', 'spec.owner'],
+        filters: { name: 'my-component', serviceName: '', status: '' },
       });
     });
 
@@ -249,38 +247,135 @@ describe('MappingsTable', () => {
     expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith({
       offset: 0,
       limit: 10,
-      search: '',
       searchFields: ['metadata.name', 'spec.owner'],
+      filters: { name: '', serviceName: '', status: '' },
     });
 
     expect(screen.getByText('1 - 10 of 25')).toBeInTheDocument();
 
     const nextButton = screen.getByLabelText('Next');
-    await act(async () => {
-      fireEvent.click(nextButton);
-    });
+    fireEvent.click(nextButton);
 
     await waitFor(() => {
       expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith({
         offset: 10,
         limit: 10,
-        search: '',
         searchFields: ['metadata.name', 'spec.owner'],
+        filters: { name: '', serviceName: '', status: '' },
       });
     });
 
     const previousButton = screen.getByLabelText('Previous');
-    await act(async () => {
-      fireEvent.click(previousButton);
-    });
+    fireEvent.click(previousButton);
 
     await waitFor(() => {
       expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith({
         offset: 0,
         limit: 10,
-        search: '',
         searchFields: ['metadata.name', 'spec.owner'],
+        filters: { name: '', serviceName: '', status: '' },
       });
     });
+  });
+
+  it('calls API with correct filter parameters when filters are applied', async () => {
+    jest.useFakeTimers();
+    mockGetEntityMappingsWithPagination.mockResolvedValue({
+      entities: [],
+      totalCount: 0,
+    });
+
+    await renderInTestApp(
+      <ApiProvider apis={apis}>
+        <QueryClientProvider client={queryClient}>
+          <MappingsTable />
+        </QueryClientProvider>
+      </ApiProvider>,
+    );
+
+    const filterButton = screen.getByRole('button', { name: 'Toggle filters' });
+    fireEvent.click(filterButton);
+
+    const nameFilter = screen.getByPlaceholderText('Filter by name');
+    fireEvent.change(nameFilter, { target: { value: 'test-service' } });
+
+    // wait because of the debounce
+    jest.advanceTimersByTime(500);
+
+    await waitFor(() => {
+      expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filters: expect.objectContaining({
+            name: 'test-service',
+          }),
+        }),
+      );
+    });
+
+    jest.useRealTimers();
+  });
+
+  it('resets offset to 0 when filters change', async () => {
+    jest.useFakeTimers();
+    const mockEntities = Array.from({ length: 10 }, (_, i) => ({
+      id: `entity-${i}`,
+      name: `service-${i}`,
+      namespace: 'default',
+      type: 'service',
+      system: 'core',
+      owner: `team-${i}`,
+      lifecycle: 'production',
+      annotations: {
+        'pagerduty.com/integration-key': `key-${i}`,
+        'pagerduty.com/service-id': `PD${i}`,
+      },
+      status: 'InSync' as const,
+    }));
+
+    mockGetEntityMappingsWithPagination.mockResolvedValue({
+      entities: mockEntities,
+      totalCount: 25,
+    });
+
+    await renderInTestApp(
+      <ApiProvider apis={apis}>
+        <QueryClientProvider client={queryClient}>
+          <MappingsTable />
+        </QueryClientProvider>
+      </ApiProvider>,
+    );
+
+    const nextButton = screen.getByLabelText('Next');
+    fireEvent.click(nextButton);
+
+    await waitFor(() => {
+      expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+        expect.objectContaining({
+          offset: 10,
+        }),
+      );
+    });
+
+    const filterButton = screen.getByRole('button', { name: 'Toggle filters' });
+    fireEvent.click(filterButton);
+
+    const serviceFilter = screen.getByPlaceholderText('Filter by service');
+    fireEvent.change(serviceFilter, { target: { value: 'pagerduty-service' } });
+
+    // wait because of the debounce
+    jest.advanceTimersByTime(500);
+
+    await waitFor(() => {
+      expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+        expect.objectContaining({
+          offset: 0,
+          filters: expect.objectContaining({
+            serviceName: 'pagerduty-service',
+          }),
+        }),
+      );
+    });
+
+    jest.useRealTimers();
   });
 });

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/MappingsTable.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/MappingsTable.tsx
@@ -50,6 +50,7 @@ export default function MappingsTable() {
     serviceName: '',
     status: '',
     teamName: '',
+    account: '',
   });
 
   const debouncedFilters = useDebounce(filters);

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/MappingsTable.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/MappingsTable.tsx
@@ -41,6 +41,22 @@ export default function MappingsTable() {
   );
   const [offset, setOffset] = useState(0);
   const [pageSize, setPageSize] = useState(10);
+  const [sort, setSort] = 
+    useState<{ column: string; direction: 'ascending' | 'descending' } | undefined>(undefined);
+  
+  
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const changeSort: (s: any) => void = ((sortDescriptor: { column: string; direction: 'ascending' | 'descending' }) => {
+    if (sort?.column === sortDescriptor.column) {
+      const newDirection = sort.direction === 'ascending' ? 'descending' : 'ascending';
+      setSort({ column: sortDescriptor.column, direction: newDirection });
+    } else {
+      setSort(sortDescriptor);
+    }
+
+    setOffset(0);
+  });
+
 
   const queryClient = useQueryClient();
   const [showFilters, setShowFilters] = useState(false);
@@ -95,6 +111,7 @@ export default function MappingsTable() {
     offset,
     pageSize,
     debouncedFilters,
+    sort,
     autoMatchResults,
   );
 
@@ -143,16 +160,18 @@ export default function MappingsTable() {
           <FilterList />
         </ButtonIcon>
       </Flex>
-      <Table selectionMode="none">
+
+      <Table sortDescriptor={sort} onSortChange={changeSort} selectionMode="none">
         <TableHeader>
-          <Column isRowHeader>Name</Column>
-          <Column isRowHeader>Team</Column>
-          <Column isRowHeader>PagerDuty service</Column>
-          <Column isRowHeader>Status</Column>
-          <Column isRowHeader>Account</Column>
+          <Column isRowHeader id='name' allowsSorting>Name</Column>
+          <Column isRowHeader id='team' allowsSorting>Team</Column>
+          <Column isRowHeader id='serviceName' allowsSorting>PagerDuty service</Column>
+          <Column isRowHeader id='status' allowsSorting>Status</Column>
+          <Column isRowHeader id='account' allowsSorting>Account</Column>
           <Column isRowHeader>Mapping Score</Column>
           <Column isRowHeader>Actions</Column>
         </TableHeader>
+
         <TableBody>
           {showFilters && (<FilterRow filters={filters} onFilterChange={handleFilterChange} />)}
           

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/MappingsTable.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/MappingsTable.tsx
@@ -8,7 +8,6 @@ import {
   CellText,
   Flex,
   ButtonIcon,
-  SearchField,
 } from '@backstage/ui';
 import { useState, useCallback } from 'react';
 import MappingsDialog from '../MappingsDialog';
@@ -16,7 +15,7 @@ import AutomaticMappingsDialog from '../AutomaticMappingsDialog';
 import AutoMappingsButton from './AutoMappingsButton';
 import StatusCell from './StatusCell';
 import { ServiceCell } from './ServiceCell';
-import { Edit, Search, Delete, FilterList } from '@mui/icons-material';
+import { Edit, Delete, FilterList } from '@mui/icons-material';
 import { FilterRow } from './FilterRow';
 import { BackstageEntity } from '../../types';
 import useDebounce from '../../../hooks/useDebounce';
@@ -43,7 +42,6 @@ export default function MappingsTable() {
   const [offset, setOffset] = useState(0);
   const [pageSize, setPageSize] = useState(10);
 
-  const [searchQuery, setSearchQuery] = useState('');
   const queryClient = useQueryClient();
   const [showFilters, setShowFilters] = useState(false);
 
@@ -51,6 +49,7 @@ export default function MappingsTable() {
     name: '',
     serviceName: '',
     status: '',
+    teamName: '',
   });
 
   const debouncedFilters = useDebounce(filters);
@@ -133,20 +132,6 @@ export default function MappingsTable() {
           onConfirmMappings={confirmMappings}
           onClearMappings={clearMatches}
           isConfirming={isConfirming}
-        />
-
-        <SearchField
-          size="small"
-          placeholder="Search for components or teams"
-          style={{
-            maxWidth: '250px',
-          }}
-          icon={<Search />}
-          value={searchQuery}
-          onChange={value => {
-            setSearchQuery(value);
-            setOffset(0);
-          }}
         />
 
         <ButtonIcon

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/hooks/useConfirmMappings.ts
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/hooks/useConfirmMappings.ts
@@ -2,13 +2,13 @@ import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useApi } from '@backstage/core-plugin-api';
 import { pagerDutyApiRef } from '../../../../api';
-import { BackstageEntity } from '../../../types';
 import { AutoMatchResults } from '../MappingsTable';
 import { MappingCounts } from '../MappingToast';
+import { FormattedBackstageEntity } from '@pagerduty/backstage-plugin-common';
 
 interface UseConfirmMappingsParams {
   autoMatchResults: AutoMatchResults;
-  mappingEntities?: BackstageEntity[];
+  mappingEntities?: FormattedBackstageEntity[];
   onSuccess: (
     successCount: number,
     totalCount: number,
@@ -34,7 +34,7 @@ export function useConfirmMappings({
       const mappingsToCreate = Object.entries(autoMatchResults).map(
         ([entityName, matchData]) => {
           const entity = mappingEntities?.find(
-            (e: BackstageEntity) => e.name === entityName,
+            (e: FormattedBackstageEntity) => e.name === entityName,
           );
 
           const entityRef = entity

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/hooks/useEntityMappings.ts
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/hooks/useEntityMappings.ts
@@ -7,7 +7,7 @@ import { AutoMatchResults } from '../MappingsTable';
 export function useEntityMappings(
   offset: number,
   pageSize: number,
-  filters: { name: string; serviceName: string; status: string },
+  filters: { name: string; serviceName: string; status: string; teamName: string; account: string },
   autoMatchResults: AutoMatchResults,
 ) {
   const pagerDutyApi = useApi(pagerDutyApiRef);

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/hooks/useEntityMappings.ts
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/hooks/useEntityMappings.ts
@@ -7,7 +7,7 @@ import { AutoMatchResults } from '../MappingsTable';
 export function useEntityMappings(
   offset: number,
   pageSize: number,
-  searchQuery: string,
+  filters: { name: string; serviceName: string; status: string },
   autoMatchResults: AutoMatchResults,
 ) {
   const pagerDutyApi = useApi(pagerDutyApiRef);
@@ -19,15 +19,15 @@ export function useEntityMappings(
       {
         offset,
         pageSize,
-        search: searchQuery,
+        filters,
       },
     ],
     queryFn: () =>
       pagerDutyApi.getEntityMappingsWithPagination({
         offset,
         limit: pageSize,
-        search: searchQuery,
         searchFields: ['metadata.name', 'spec.owner'],
+        filters,
       }),
   });
 

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/hooks/useEntityMappings.ts
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/hooks/useEntityMappings.ts
@@ -1,13 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
 import { useApi } from '@backstage/core-plugin-api';
 import { pagerDutyApiRef } from '../../../../api';
-import { BackstageEntity } from '../../../types';
 import { AutoMatchResults } from '../MappingsTable';
+import { FormattedBackstageEntity } from '@pagerduty/backstage-plugin-common';
+import { BackstageEntity } from '../../../types';
 
 export function useEntityMappings(
   offset: number,
   pageSize: number,
   filters: { name: string; serviceName: string; status: string; teamName: string; account: string },
+  sort: { column: string; direction: 'ascending' | 'descending' } | undefined,
   autoMatchResults: AutoMatchResults,
 ) {
   const pagerDutyApi = useApi(pagerDutyApiRef);
@@ -20,20 +22,20 @@ export function useEntityMappings(
         offset,
         pageSize,
         filters,
+        sort,
       },
     ],
     queryFn: () =>
       pagerDutyApi.getEntityMappingsWithPagination({
         offset,
         limit: pageSize,
-        searchFields: ['metadata.name', 'spec.owner'],
         filters,
+        sort,
       }),
   });
 
   // Merge auto-match results with entities
-  const entitiesWithScores = mappings?.entities.map(
-    (entity: BackstageEntity) => {
+  const entitiesWithScores = mappings?.entities.map((entity: FormattedBackstageEntity): BackstageEntity => {
       const matchResult = autoMatchResults[entity.name];
 
       if (matchResult) {
@@ -47,7 +49,7 @@ export function useEntityMappings(
         };
       }
 
-      return entity;
+      return entity as BackstageEntity;
     },
   );
 

--- a/plugins/backstage-plugin/src/hooks/useDebounce.ts
+++ b/plugins/backstage-plugin/src/hooks/useDebounce.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 
-export default function useDebounce(value: string, delay: number = 500) {
+export default function useDebounce<T>(value: T, delay: number = 500) {
   const [debounced, setDebounced] = useState(value);
   useEffect(() => {
     const handler = setTimeout(() => setDebounced(value), delay);


### PR DESCRIPTION
### Description

This PR implements filtering capabilities for the service mapping table. Users can now filter the mapping table by:
- **Entity Name**: Full-text search via Backstage Catalog API
- **Team Name**: Full-text search via Backstage Catalog API
- **Account**: Match via entity mappings
- **PagerDuty Service Name**: Query PagerDuty API and match via entity mappings
- **Status**: Filter by InSync, OutOfSync, NotMapped, or Error states

The filter UI is hidden by default and can be toggled using a filter icon button. When filters are applied, pagination automatically resets to the first page.

<img width="2237" height="612" alt="image" src="https://github.com/user-attachments/assets/a9ac6887-a2be-412e-9e48-6e53758dcbf1" />

<img width="2219" height="700" alt="image" src="https://github.com/user-attachments/assets/d2f2b11e-a1d5-46e5-a47a-3c968e1e4b3b" />


### Affected plugin

- [x] backstage-plugin
- [x] backstage-plugin-backend
- [ ] backstage-plugin-scaffolder-actions
- [ ] backstage-plugin-entity-processor

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes have been tested in dark theme
- [x] Changes are documented
- [x] Changes generate _no new warnings_
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

### Notes
- [x] This code was AI assisted
- Sorting functionality deferred to a future iteration

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.