### PR TITLE
feat: add sorting capabilities to service mapping table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ db
 
 # Claude code
 .claude
+CLAUDE.md

--- a/plugins/backstage-plugin-common/src/types.ts
+++ b/plugins/backstage-plugin-common/src/types.ts
@@ -304,7 +304,7 @@ export type FormattedBackstageEntity = {
   serviceUrl?: string;
   team?: string;
   escalationPolicy?: string;
-  status?: 'NotMapped' | 'InSync' | 'OutOfSync';
+  status?: 'NotMapped' | 'InSync' | 'OutOfSync' | 'ErrorWhenFetchingService';
   account?: string;
 };
 

--- a/plugins/backstage-plugin/src/api/client.ts
+++ b/plugins/backstage-plugin/src/api/client.ts
@@ -142,8 +142,6 @@ export class PagerDutyClient implements PagerDutyApi {
   async getEntityMappingsWithPagination(options: {
     offset: number;
     limit: number;
-    search?: string;
-    searchFields?: string[];
     filters?: {
       name?: string;
       serviceName?: string;
@@ -151,6 +149,7 @@ export class PagerDutyClient implements PagerDutyApi {
       teamName?: string;
       account?: string;
     };
+    sort?: { column: string; direction: 'ascending' | 'descending' };
   }): Promise<PagerDutyEnhancedEntityMappingsResponse> {
     const url = `${await this.config.discoveryApi.getBaseUrl(
       'pagerduty',
@@ -159,9 +158,8 @@ export class PagerDutyClient implements PagerDutyApi {
     const body = JSON.stringify({
       offset: options.offset,
       limit: options.limit,
-      search: options.search,
-      searchFields: options.searchFields || ['metadata.name', 'spec.owner'],
       filters: options.filters || {},
+      sort: options.sort,
     });
 
     const requestOptions = {

--- a/plugins/backstage-plugin/src/api/types.ts
+++ b/plugins/backstage-plugin/src/api/types.ts
@@ -73,12 +73,14 @@ export interface PagerDutyApi {
   getEntityMappingsWithPagination(options: {
     offset: number;
     limit: number;
-    searchFields?: string[];
     filters?: {
       name?: string;
       serviceName?: string;
       status?: string;
+      teamName?: string;
+      account?: string;
     };
+    sort?: { column: string; direction: 'ascending' | 'descending' };
   }): Promise<PagerDutyEnhancedEntityMappingsResponse>;
 
   /**

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/MappingsTable.test.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/MappingsTable.test.tsx
@@ -281,7 +281,7 @@ describe('MappingsTable', () => {
         offset: 0,
         limit: 10,
         filters: { name: '', serviceName: '', status: '', teamName: '', account: '' },
-        Sort: undefined
+        sort: undefined
       });
     });
   });

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/MappingsTable.test.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/MappingsTable.test.tsx
@@ -215,8 +215,8 @@ describe('MappingsTable', () => {
       expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith({
         offset: 0,
         limit: 10,
-        searchFields: ['metadata.name', 'spec.owner'],
         filters: { name: 'my-component', serviceName: '', status: '', teamName: '', account: '' },
+        sort: undefined
       });
     });
 
@@ -255,8 +255,8 @@ describe('MappingsTable', () => {
     expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith({
       offset: 0,
       limit: 10,
-      searchFields: ['metadata.name', 'spec.owner'],
       filters: { name: '', serviceName: '', status: '', teamName: '', account: '' },
+      sort: undefined
     });
 
     expect(screen.getByText('1 - 10 of 25')).toBeInTheDocument();
@@ -268,8 +268,8 @@ describe('MappingsTable', () => {
       expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith({
         offset: 10,
         limit: 10,
-        searchFields: ['metadata.name', 'spec.owner'],
         filters: { name: '', serviceName: '', status: '', teamName: '', account: '' },
+        sort: undefined
       });
     });
 
@@ -280,8 +280,8 @@ describe('MappingsTable', () => {
       expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith({
         offset: 0,
         limit: 10,
-        searchFields: ['metadata.name', 'spec.owner'],
         filters: { name: '', serviceName: '', status: '', teamName: '', account: '' },
+        Sort: undefined
       });
     });
   });
@@ -484,5 +484,320 @@ describe('MappingsTable', () => {
     });
 
     jest.useRealTimers();
+  });
+
+  describe('sorting', () => {
+    it('calls API with sort parameter when Name column header is clicked', async () => {
+      mockGetEntityMappingsWithPagination.mockResolvedValue({
+        entities: [],
+        totalCount: 0,
+      });
+
+      await renderInTestApp(
+        <ApiProvider apis={apis}>
+          <QueryClientProvider client={queryClient}>
+            <MappingsTable />
+          </QueryClientProvider>
+        </ApiProvider>,
+      );
+
+      const nameColumnHeader = screen.getByText('Name');
+      fireEvent.click(nameColumnHeader);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sort: { column: 'name', direction: 'ascending' },
+          }),
+        );
+      });
+    });
+
+    it('toggles sort direction when clicking the same column header twice', async () => {
+      mockGetEntityMappingsWithPagination.mockResolvedValue({
+        entities: [],
+        totalCount: 0,
+      });
+
+      await renderInTestApp(
+        <ApiProvider apis={apis}>
+          <QueryClientProvider client={queryClient}>
+            <MappingsTable />
+          </QueryClientProvider>
+        </ApiProvider>,
+      );
+
+      const nameColumnHeader = screen.getByText('Name');
+
+      // First click - ascending
+      fireEvent.click(nameColumnHeader);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sort: { column: 'name', direction: 'ascending' },
+          }),
+        );
+      });
+
+      // Second click - descending
+      fireEvent.click(nameColumnHeader);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sort: { column: 'name', direction: 'descending' },
+          }),
+        );
+      });
+    });
+
+    it('calls API with sort parameter when Team column header is clicked', async () => {
+      mockGetEntityMappingsWithPagination.mockResolvedValue({
+        entities: [],
+        totalCount: 0,
+      });
+
+      await renderInTestApp(
+        <ApiProvider apis={apis}>
+          <QueryClientProvider client={queryClient}>
+            <MappingsTable />
+          </QueryClientProvider>
+        </ApiProvider>,
+      );
+
+      const teamColumnHeader = screen.getByText('Team');
+      fireEvent.click(teamColumnHeader);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sort: { column: 'team', direction: 'ascending' },
+          }),
+        );
+      });
+    });
+
+    it('calls API with sort parameter when PagerDuty service column header is clicked', async () => {
+      mockGetEntityMappingsWithPagination.mockResolvedValue({
+        entities: [],
+        totalCount: 0,
+      });
+
+      await renderInTestApp(
+        <ApiProvider apis={apis}>
+          <QueryClientProvider client={queryClient}>
+            <MappingsTable />
+          </QueryClientProvider>
+        </ApiProvider>,
+      );
+
+      const serviceColumnHeader = screen.getByText('PagerDuty service');
+      fireEvent.click(serviceColumnHeader);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sort: { column: 'serviceName', direction: 'ascending' },
+          }),
+        );
+      });
+    });
+
+    it('calls API with sort parameter when Status column header is clicked', async () => {
+      mockGetEntityMappingsWithPagination.mockResolvedValue({
+        entities: [],
+        totalCount: 0,
+      });
+
+      await renderInTestApp(
+        <ApiProvider apis={apis}>
+          <QueryClientProvider client={queryClient}>
+            <MappingsTable />
+          </QueryClientProvider>
+        </ApiProvider>,
+      );
+
+      const statusColumnHeader = screen.getByText('Status');
+      fireEvent.click(statusColumnHeader);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sort: { column: 'status', direction: 'ascending' },
+          }),
+        );
+      });
+    });
+
+    it('calls API with sort parameter when Account column header is clicked', async () => {
+      mockGetEntityMappingsWithPagination.mockResolvedValue({
+        entities: [],
+        totalCount: 0,
+      });
+
+      await renderInTestApp(
+        <ApiProvider apis={apis}>
+          <QueryClientProvider client={queryClient}>
+            <MappingsTable />
+          </QueryClientProvider>
+        </ApiProvider>,
+      );
+
+      const accountColumnHeader = screen.getByText('Account');
+      fireEvent.click(accountColumnHeader);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sort: { column: 'account', direction: 'ascending' },
+          }),
+        );
+      });
+    });
+
+    it('switches sort column when clicking different column headers', async () => {
+      mockGetEntityMappingsWithPagination.mockResolvedValue({
+        entities: [],
+        totalCount: 0,
+      });
+
+      await renderInTestApp(
+        <ApiProvider apis={apis}>
+          <QueryClientProvider client={queryClient}>
+            <MappingsTable />
+          </QueryClientProvider>
+        </ApiProvider>,
+      );
+
+      // Sort by name
+      const nameColumnHeader = screen.getByText('Name');
+      fireEvent.click(nameColumnHeader);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sort: { column: 'name', direction: 'ascending' },
+          }),
+        );
+      });
+
+      // Switch to sort by team
+      const teamColumnHeader = screen.getByText('Team');
+      fireEvent.click(teamColumnHeader);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sort: { column: 'team', direction: 'ascending' },
+          }),
+        );
+      });
+    });
+
+    it('resets offset to 0 when sort changes', async () => {
+      const mockEntities = Array.from({ length: 10 }, (_, i) => ({
+        id: `entity-${i}`,
+        name: `service-${i}`,
+        namespace: 'default',
+        type: 'service',
+        system: 'core',
+        owner: `team-${i}`,
+        lifecycle: 'production',
+        annotations: {
+          'pagerduty.com/integration-key': `key-${i}`,
+          'pagerduty.com/service-id': `PD${i}`,
+        },
+        status: 'InSync' as const,
+      }));
+
+      mockGetEntityMappingsWithPagination.mockResolvedValue({
+        entities: mockEntities,
+        totalCount: 25,
+      });
+
+      await renderInTestApp(
+        <ApiProvider apis={apis}>
+          <QueryClientProvider client={queryClient}>
+            <MappingsTable />
+          </QueryClientProvider>
+        </ApiProvider>,
+      );
+
+      // Navigate to second page
+      const nextButton = screen.getByLabelText('Next');
+      fireEvent.click(nextButton);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            offset: 10,
+          }),
+        );
+      });
+
+      // Click sort column - should reset to offset 0
+      const nameColumnHeader = screen.getByText('Name');
+      fireEvent.click(nameColumnHeader);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            offset: 0,
+            sort: { column: 'name', direction: 'ascending' },
+          }),
+        );
+      });
+    });
+
+    it('maintains sort when filters are applied', async () => {
+      jest.useFakeTimers();
+      mockGetEntityMappingsWithPagination.mockResolvedValue({
+        entities: [],
+        totalCount: 0,
+      });
+
+      await renderInTestApp(
+        <ApiProvider apis={apis}>
+          <QueryClientProvider client={queryClient}>
+            <MappingsTable />
+          </QueryClientProvider>
+        </ApiProvider>,
+      );
+
+      // Apply sort first
+      const nameColumnHeader = screen.getByText('Name');
+      fireEvent.click(nameColumnHeader);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            sort: { column: 'name', direction: 'ascending' },
+          }),
+        );
+      });
+
+      // Apply filter
+      const filterButton = screen.getByRole('button', { name: 'Toggle filters' });
+      fireEvent.click(filterButton);
+
+      const nameFilter = screen.getByPlaceholderText('Filter by name');
+      fireEvent.change(nameFilter, { target: { value: 'test-service' } });
+
+      jest.advanceTimersByTime(500);
+
+      await waitFor(() => {
+        expect(mockGetEntityMappingsWithPagination).toHaveBeenCalledWith(
+          expect.objectContaining({
+            filters: expect.objectContaining({
+              name: 'test-service',
+            }),
+            sort: { column: 'name', direction: 'ascending' },
+          }),
+        );
+      });
+
+      jest.useRealTimers();
+    });
   });
 });

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/MappingsTable.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/MappingsTable.tsx
@@ -41,6 +41,22 @@ export default function MappingsTable() {
   );
   const [offset, setOffset] = useState(0);
   const [pageSize, setPageSize] = useState(10);
+  const [sort, setSort] = 
+    useState<{ column: string; direction: 'ascending' | 'descending' } | undefined>(undefined);
+  
+  
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const changeSort: (s: any) => void = ((sortDescriptor: { column: string; direction: 'ascending' | 'descending' }) => {
+    if (sort?.column === sortDescriptor.column) {
+      const newDirection = sort.direction === 'ascending' ? 'descending' : 'ascending';
+      setSort({ column: sortDescriptor.column, direction: newDirection });
+    } else {
+      setSort(sortDescriptor);
+    }
+
+    setOffset(0);
+  });
+
 
   const queryClient = useQueryClient();
   const [showFilters, setShowFilters] = useState(false);
@@ -95,6 +111,7 @@ export default function MappingsTable() {
     offset,
     pageSize,
     debouncedFilters,
+    sort,
     autoMatchResults,
   );
 
@@ -143,16 +160,18 @@ export default function MappingsTable() {
           <FilterList />
         </ButtonIcon>
       </Flex>
-      <Table selectionMode="none">
+
+      <Table sortDescriptor={sort} onSortChange={changeSort} selectionMode="none">
         <TableHeader>
-          <Column isRowHeader>Name</Column>
-          <Column isRowHeader>Team</Column>
-          <Column isRowHeader>PagerDuty service</Column>
-          <Column isRowHeader>Status</Column>
-          <Column isRowHeader>Account</Column>
+          <Column isRowHeader id='name' allowsSorting>Name</Column>
+          <Column isRowHeader id='team' allowsSorting>Team</Column>
+          <Column isRowHeader id='serviceName' allowsSorting>PagerDuty service</Column>
+          <Column isRowHeader id='status' allowsSorting>Status</Column>
+          <Column isRowHeader id='account' allowsSorting>Account</Column>
           <Column isRowHeader>Mapping Score</Column>
           <Column isRowHeader>Actions</Column>
         </TableHeader>
+
         <TableBody>
           {showFilters && (<FilterRow filters={filters} onFilterChange={handleFilterChange} />)}
           

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/hooks/useConfirmMappings.ts
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/hooks/useConfirmMappings.ts
@@ -2,13 +2,13 @@ import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useApi } from '@backstage/core-plugin-api';
 import { pagerDutyApiRef } from '../../../../api';
-import { BackstageEntity } from '../../../types';
 import { AutoMatchResults } from '../MappingsTable';
 import { MappingCounts } from '../MappingToast';
+import { FormattedBackstageEntity } from '@pagerduty/backstage-plugin-common';
 
 interface UseConfirmMappingsParams {
   autoMatchResults: AutoMatchResults;
-  mappingEntities?: BackstageEntity[];
+  mappingEntities?: FormattedBackstageEntity[];
   onSuccess: (
     successCount: number,
     totalCount: number,
@@ -34,7 +34,7 @@ export function useConfirmMappings({
       const mappingsToCreate = Object.entries(autoMatchResults).map(
         ([entityName, matchData]) => {
           const entity = mappingEntities?.find(
-            (e: BackstageEntity) => e.name === entityName,
+            (e: FormattedBackstageEntity) => e.name === entityName,
           );
 
           const entityRef = entity

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/hooks/useEntityMappings.ts
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsTable/hooks/useEntityMappings.ts
@@ -1,13 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
 import { useApi } from '@backstage/core-plugin-api';
 import { pagerDutyApiRef } from '../../../../api';
-import { BackstageEntity } from '../../../types';
 import { AutoMatchResults } from '../MappingsTable';
+import { FormattedBackstageEntity } from '@pagerduty/backstage-plugin-common';
+import { BackstageEntity } from '../../../types';
 
 export function useEntityMappings(
   offset: number,
   pageSize: number,
   filters: { name: string; serviceName: string; status: string; teamName: string; account: string },
+  sort: { column: string; direction: 'ascending' | 'descending' } | undefined,
   autoMatchResults: AutoMatchResults,
 ) {
   const pagerDutyApi = useApi(pagerDutyApiRef);
@@ -20,20 +22,20 @@ export function useEntityMappings(
         offset,
         pageSize,
         filters,
+        sort,
       },
     ],
     queryFn: () =>
       pagerDutyApi.getEntityMappingsWithPagination({
         offset,
         limit: pageSize,
-        searchFields: ['metadata.name', 'spec.owner'],
         filters,
+        sort,
       }),
   });
 
   // Merge auto-match results with entities
-  const entitiesWithScores = mappings?.entities.map(
-    (entity: BackstageEntity) => {
+  const entitiesWithScores = mappings?.entities.map((entity: FormattedBackstageEntity): BackstageEntity => {
       const matchResult = autoMatchResults[entity.name];
 
       if (matchResult) {
@@ -47,7 +49,7 @@ export function useEntityMappings(
         };
       }
 
-      return entity;
+      return entity as BackstageEntity;
     },
   );
 


### PR DESCRIPTION
### Description

This PR adds comprehensive sorting functionality to the service mapping table, enabling users to sort by name, team, service name, status, and account columns. The sorting implementation includes both frontend UI updates and backend API support with proper validation and testing.

**Code Assistance:** [x] This PR was code assisted

### Affected plugin

- [x] backstage-plugin
- [x] backstage-plugin-backend
- [x] backstage-plugin-common
- [ ] backstage-plugin-scaffolder-actions
- [ ] backstage-plugin-entity-processor

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes have been tested in dark theme
- [x] Changes are documented
- [x] Changes generate _no new warnings_
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.