### PR TITLE
chore: add X-PagerDuty-Client header to all API requests

### DIFF
--- a/.changeset/chatty-corners-unite.md
+++ b/.changeset/chatty-corners-unite.md
@@ -1,0 +1,5 @@
+---
+'@pagerduty/backstage-plugin-backend': patch
+---
+
+Include x-pagerduty-client header in PagerDuty API requests

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ db
 
 # Claude code
 .claude
+CLAUDE.md

--- a/plugins/backstage-plugin-backend/src/apis/pagerduty.test.ts
+++ b/plugins/backstage-plugin-backend/src/apis/pagerduty.test.ts
@@ -46,6 +46,11 @@ describe('PagerDuty API', () => {
       id: 'testaccount',
       apiBaseUrl: 'https://mock.api.pagerduty.com',
       eventsBaseUrl: 'https://mock.events.pagerduty.com',
+      oauth: {
+        clientId: 'mock-client-id',
+        clientSecret: 'mock-client-secret',
+        subDomain: 'testaccount',
+      },
     };
 
     insertEndpointConfig(mockAccount);
@@ -1502,5 +1507,101 @@ describe('PagerDuty API', () => {
         },
       );
     });
+  });
+
+  describe('X-PagerDuty-Client header', () => {
+    it.each(testInputs)(
+      'should include X-PagerDuty-Client header with correct format',
+      async () => {
+        mocked(fetch).mockReturnValue(
+          mockedResponse(200, {
+            escalation_policies: [{ id: 'P0L1CY1D', name: 'Test Policy' }],
+          }),
+        );
+
+        await getAllEscalationPolicies();
+
+        expect(fetch).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              'X-PagerDuty-Client':
+                '"Backstage" <https://testaccount.backstage.com>',
+            }),
+          }),
+        );
+      },
+    );
+
+    it.each(testInputs)(
+      'should include X-PagerDuty-Client header in service requests',
+      async () => {
+        const serviceId = 'SERV1C31D';
+        mocked(fetch).mockReturnValue(
+          mockedResponse(200, {
+            service: {
+              id: serviceId,
+              name: 'Test Service',
+              status: 'active',
+              escalation_policy: {
+                id: 'P0L1CY1D',
+                name: 'Test Policy',
+                type: 'escalation_policy_reference',
+                html_url: 'https://example.com',
+              },
+              html_url: 'https://example.com',
+            },
+          }),
+        );
+
+        await getServiceById(serviceId);
+
+        expect(fetch).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              'X-PagerDuty-Client':
+                '"Backstage" <https://testaccount.backstage.com>',
+            }),
+          }),
+        );
+      },
+    );
+
+    it.each(testInputs)(
+      'should include X-PagerDuty-Client header in oncall requests',
+      async () => {
+        const escalationPolicyId = '12345';
+        mocked(fetch).mockReturnValue(
+          mockedResponse(200, {
+            oncalls: [
+              {
+                user: {
+                  id: 'userId1',
+                  summary: 'John Doe',
+                  name: 'John Doe',
+                  email: 'john.doe@email.com',
+                  avatar_url: 'https://example.com/avatar',
+                  html_url: 'https://example.com/user',
+                },
+                escalation_level: 1,
+              },
+            ],
+          }),
+        );
+
+        await getOncallUsers(escalationPolicyId);
+
+        expect(fetch).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            headers: expect.objectContaining({
+              'X-PagerDuty-Client':
+                '"Backstage" <https://testaccount.backstage.com>',
+            }),
+          }),
+        );
+      },
+    );
   });
 });

--- a/plugins/backstage-plugin-backend/src/apis/pagerduty.test.ts
+++ b/plugins/backstage-plugin-backend/src/apis/pagerduty.test.ts
@@ -17,8 +17,8 @@ import {
   getServiceByIntegrationKey,
   getServiceMetrics,
   getServiceStandards,
-  insertEndpointConfig,
-  setFallbackEndpointConfig,
+  insertAccountConfig,
+  setFallbackAccountConfig,
 } from './pagerduty';
 
 import { mocked } from 'jest-mock';
@@ -53,8 +53,8 @@ describe('PagerDuty API', () => {
       },
     };
 
-    insertEndpointConfig(mockAccount);
-    setFallbackEndpointConfig(mockAccount);
+    insertAccountConfig(mockAccount);
+    setFallbackAccountConfig(mockAccount);
   });
 
   afterEach(() => {

--- a/plugins/backstage-plugin-backend/src/apis/pagerduty.ts
+++ b/plugins/backstage-plugin-backend/src/apis/pagerduty.ts
@@ -41,11 +41,18 @@ const EndpointConfig: Record<string, PagerDutyEndpointConfig> = {};
 let fallbackEndpointConfig: PagerDutyEndpointConfig;
 let isLegacyConfig = false;
 
+const SubdomainConfig: Record<string, string> = {};
+let fallbackSubdomain: string | undefined;
+
 export function setFallbackEndpointConfig(account: PagerDutyAccountConfig) {
   fallbackEndpointConfig = {
     eventsBaseUrl: account.eventsBaseUrl ?? 'https://events.pagerduty.com/v2',
     apiBaseUrl: account.apiBaseUrl ?? 'https://api.pagerduty.com',
   };
+
+  if (account.oauth?.subDomain) {
+    fallbackSubdomain = account.oauth.subDomain;
+  }
 }
 
 export function insertEndpointConfig(account: PagerDutyAccountConfig) {
@@ -53,20 +60,23 @@ export function insertEndpointConfig(account: PagerDutyAccountConfig) {
     eventsBaseUrl: account.eventsBaseUrl ?? 'https://events.pagerduty.com/v2',
     apiBaseUrl: account.apiBaseUrl ?? 'https://api.pagerduty.com',
   };
+
+  if (account.oauth?.subDomain) {
+    SubdomainConfig[account.id] = account.oauth.subDomain;
+  }
 }
 
 export function loadPagerDutyEndpointsFromConfig(
   config: RootConfigService,
   logger: LoggerService,
 ) {
-  if (config.getOptional('pagerDuty.accounts')) {
+  const accounts = config.getOptional<PagerDutyAccountConfig[]>('pagerDuty.accounts');
+
+  if (accounts) {
     logger.debug(
       `New accounts configuration detected. Loading PagerDuty endpoints from config.`,
     );
     isLegacyConfig = false;
-
-    const accounts =
-      config.getOptional<PagerDutyAccountConfig[]>('pagerDuty.accounts');
 
     if (accounts?.length === 1) {
       logger.debug(
@@ -82,6 +92,10 @@ export function loadPagerDutyEndpointsFromConfig(
             ? accounts[0].apiBaseUrl
             : 'https://api.pagerduty.com',
       };
+
+      if (accounts[0].oauth?.subDomain) {
+        SubdomainConfig.default = accounts[0].oauth.subDomain;
+      }
     } else {
       logger.debug(
         `Multiple account configuration detected. Loading PagerDuty endpoints from config.`,
@@ -89,9 +103,16 @@ export function loadPagerDutyEndpointsFromConfig(
       accounts?.forEach(account => {
         if (account.isDefault) {
           setFallbackEndpointConfig(account);
+          if (account.oauth?.subDomain) {
+            fallbackSubdomain = account.oauth.subDomain;
+          }
         }
 
         insertEndpointConfig(account);
+
+        if (account.oauth?.subDomain) {
+          SubdomainConfig[account.id] = account.oauth.subDomain;
+        }
       });
     }
   } else {
@@ -108,6 +129,12 @@ export function loadPagerDutyEndpointsFromConfig(
           ? config.getString('pagerDuty.apiBaseUrl')
           : 'https://api.pagerduty.com',
     };
+
+    const legacySubdomain = config.getOptionalString('pagerDuty.oauth.subDomain');
+    if (legacySubdomain) {
+      SubdomainConfig.default = legacySubdomain;
+      fallbackSubdomain = legacySubdomain;
+    }
   }
 }
 
@@ -123,6 +150,30 @@ function getApiBaseUrl(account?: string): string {
   return fallbackEndpointConfig.apiBaseUrl;
 }
 
+function getSubdomain(account?: string): string {
+  if (isLegacyConfig === true) {
+    return SubdomainConfig.default;
+  }
+
+  if (account && account !== 'default') {
+    return SubdomainConfig[account] ?? fallbackSubdomain ?? SubdomainConfig.default;
+  }
+
+  return fallbackSubdomain ?? SubdomainConfig.default;
+}
+
+async function getDefaultHeaders(account?: string): Promise<Record<string, string>> {
+  const subdomain = getSubdomain(account);
+  const clientHeader = `"Backstage" <https://${subdomain}.backstage.com>`;
+
+  return {
+    Authorization: await getAuthToken(account),
+    Accept: 'application/vnd.pagerduty+json;version=2',
+    'Content-Type': 'application/json',
+    'X-PagerDuty-Client': clientHeader,
+  };
+}
+
 // Supporting router
 export async function addServiceRelationsToService(
   serviceRelations: PagerDutyServiceDependency[],
@@ -131,11 +182,7 @@ export async function addServiceRelationsToService(
   let response: Response;
   const options: RequestInit = {
     method: 'POST',
-    headers: {
-      Authorization: await getAuthToken(account),
-      Accept: 'application/vnd.pagerduty+json;version=2',
-      'Content-Type': 'application/json',
-    },
+    headers: await getDefaultHeaders(account),
     body: JSON.stringify({
       relationships: serviceRelations,
     }),
@@ -202,11 +249,7 @@ export async function removeServiceRelationsFromService(
   let response: Response;
   const options: RequestInit = {
     method: 'POST',
-    headers: {
-      Authorization: await getAuthToken(account),
-      Accept: 'application/vnd.pagerduty+json;version=2',
-      'Content-Type': 'application/json',
-    },
+    headers: await getDefaultHeaders(account),
     body: JSON.stringify({
       relationships: serviceRelations,
     }),
@@ -273,11 +316,7 @@ export async function getServiceRelationshipsById(
   let response: Response;
   const options: RequestInit = {
     method: 'GET',
-    headers: {
-      Authorization: await getAuthToken(account),
-      Accept: 'application/vnd.pagerduty+json;version=2',
-      'Content-Type': 'application/json',
-    },
+    headers: await getDefaultHeaders(account),
   };
 
   const apiBaseUrl = getApiBaseUrl(account);
@@ -343,11 +382,7 @@ async function getEscalationPolicies(
   const params = `total=true&sort_by=name&offset=${offset}&limit=${limit}`;
   const options: RequestInit = {
     method: 'GET',
-    headers: {
-      Authorization: await getAuthToken(account),
-      Accept: 'application/vnd.pagerduty+json;version=2',
-      'Content-Type': 'application/json',
-    },
+    headers: await getDefaultHeaders(account),
   };
 
   const apiBaseUrl = getApiBaseUrl(account);
@@ -457,11 +492,7 @@ export async function isEventNoiseReductionEnabled(
   const baseUrl = 'https://api.pagerduty.com';
   const options: RequestInit = {
     method: 'GET',
-    headers: {
-      Authorization: await getAuthToken(account),
-      Accept: 'application/vnd.pagerduty+json;version=2',
-      'Content-Type': 'application/json',
-    },
+    headers: await getDefaultHeaders(account),
   };
 
   try {
@@ -517,11 +548,7 @@ export async function getOncallUsers(
   const params = `time_zone=UTC&include[]=users&escalation_policy_ids[]=${escalationPolicy}`;
   const options: RequestInit = {
     method: 'GET',
-    headers: {
-      Authorization: await getAuthToken(account),
-      Accept: 'application/vnd.pagerduty+json;version=2',
-      'Content-Type': 'application/json',
-    },
+    headers: await getDefaultHeaders(account),
   };
 
   const apiBaseUrl = getApiBaseUrl(account);
@@ -606,15 +633,10 @@ export async function getServiceById(
 ): Promise<PagerDutyService> {
   let response: Response;
   const params = `time_zone=UTC&include[]=integrations&include[]=escalation_policies`;
-  const token = await getAuthToken(account);
 
   const options: RequestInit = {
     method: 'GET',
-    headers: {
-      Authorization: token,
-      Accept: 'application/vnd.pagerduty+json;version=2',
-      'Content-Type': 'application/json',
-    },
+    headers: await getDefaultHeaders(account),
   };
 
   const apiBaseUrl = getApiBaseUrl(account);
@@ -677,15 +699,10 @@ export async function getServiceByIntegrationKey(
 ): Promise<PagerDutyService> {
   let response: Response;
   const params = `query=${integrationKey}&time_zone=UTC&include[]=integrations&include[]=escalation_policies`;
-  const token = await getAuthToken(account);
 
   const options: RequestInit = {
     method: 'GET',
-    headers: {
-      Authorization: token,
-      Accept: 'application/vnd.pagerduty+json;version=2',
-      'Content-Type': 'application/json',
-    },
+    headers: await getDefaultHeaders(account),
   };
 
   const apiBaseUrl = getApiBaseUrl(account);
@@ -754,15 +771,9 @@ export async function getAllServices(): Promise<PagerDutyService[]> {
       let response: Response;
       const params = `time_zone=UTC&include[]=integrations&include[]=escalation_policies&include[]=teams&total=true`;
 
-      const token = await getAuthToken(account);
-
       const options: RequestInit = {
         method: 'GET',
-        headers: {
-          Authorization: token,
-          Accept: 'application/vnd.pagerduty+json;version=2',
-          'Content-Type': 'application/json',
-        },
+        headers: await getDefaultHeaders(account),
       };
 
       const apiBaseUrl = getApiBaseUrl(account);
@@ -833,11 +844,7 @@ export async function getChangeEvents(
   const params = `limit=5&time_zone=UTC&sort_by=timestamp`;
   const options: RequestInit = {
     method: 'GET',
-    headers: {
-      Authorization: await getAuthToken(account),
-      Accept: 'application/vnd.pagerduty+json;version=2',
-      'Content-Type': 'application/json',
-    },
+    headers: await getDefaultHeaders(account),
   };
 
   const apiBaseUrl = getApiBaseUrl(account);
@@ -906,11 +913,7 @@ export async function getIncidents(
 
   const options: RequestInit = {
     method: 'GET',
-    headers: {
-      Authorization: await getAuthToken(account),
-      Accept: 'application/vnd.pagerduty+json;version=2',
-      'Content-Type': 'application/json',
-    },
+    headers: await getDefaultHeaders(account),
   };
 
   const apiBaseUrl = getApiBaseUrl(account);
@@ -977,11 +980,7 @@ export async function getServiceStandards(
 
   const options: RequestInit = {
     method: 'GET',
-    headers: {
-      Authorization: await getAuthToken(account),
-      Accept: 'application/vnd.pagerduty+json;version=2',
-      'Content-Type': 'application/json',
-    },
+    headers: await getDefaultHeaders(account),
   };
 
   const apiBaseUrl = getApiBaseUrl(account);
@@ -1051,11 +1050,7 @@ export async function getServiceMetrics(
 
   const options: RequestInit = {
     method: 'POST',
-    headers: {
-      Authorization: await getAuthToken(account),
-      Accept: 'application/vnd.pagerduty+json;version=2',
-      'Content-Type': 'application/json',
-    },
+    headers: await getDefaultHeaders(account),
     body: body,
   };
 
@@ -1117,7 +1112,6 @@ export async function createServiceIntegration({
 
   const apiBaseUrl = getApiBaseUrl(account);
   const baseUrl = `${apiBaseUrl}/services`;
-  const token = await getAuthToken(account);
 
   const options: RequestInit = {
     method: 'POST',
@@ -1134,11 +1128,7 @@ export async function createServiceIntegration({
         },
       },
     }),
-    headers: {
-      Authorization: token,
-      Accept: 'application/vnd.pagerduty+json;version=2',
-      'Content-Type': 'application/json',
-    },
+    headers: await getDefaultHeaders(account),
   };
 
   try {

--- a/plugins/backstage-plugin-backend/src/apis/pagerduty.ts
+++ b/plugins/backstage-plugin-backend/src/apis/pagerduty.ts
@@ -44,7 +44,7 @@ let isLegacyConfig = false;
 const SubdomainConfig: Record<string, string> = {};
 let fallbackSubdomain: string | undefined;
 
-export function setFallbackEndpointConfig(account: PagerDutyAccountConfig) {
+export function setFallbackAccountConfig(account: PagerDutyAccountConfig) {
   fallbackEndpointConfig = {
     eventsBaseUrl: account.eventsBaseUrl ?? 'https://events.pagerduty.com/v2',
     apiBaseUrl: account.apiBaseUrl ?? 'https://api.pagerduty.com',
@@ -55,7 +55,7 @@ export function setFallbackEndpointConfig(account: PagerDutyAccountConfig) {
   }
 }
 
-export function insertEndpointConfig(account: PagerDutyAccountConfig) {
+export function insertAccountConfig(account: PagerDutyAccountConfig) {
   EndpointConfig[account.id] = {
     eventsBaseUrl: account.eventsBaseUrl ?? 'https://events.pagerduty.com/v2',
     apiBaseUrl: account.apiBaseUrl ?? 'https://api.pagerduty.com',
@@ -102,17 +102,10 @@ export function loadPagerDutyEndpointsFromConfig(
       );
       accounts?.forEach(account => {
         if (account.isDefault) {
-          setFallbackEndpointConfig(account);
-          if (account.oauth?.subDomain) {
-            fallbackSubdomain = account.oauth.subDomain;
-          }
+          setFallbackAccountConfig(account);
         }
 
-        insertEndpointConfig(account);
-
-        if (account.oauth?.subDomain) {
-          SubdomainConfig[account.id] = account.oauth.subDomain;
-        }
+        insertAccountConfig(account);
       });
     }
   } else {
@@ -131,9 +124,9 @@ export function loadPagerDutyEndpointsFromConfig(
     };
 
     const legacySubdomain = config.getOptionalString('pagerDuty.oauth.subDomain');
+
     if (legacySubdomain) {
       SubdomainConfig.default = legacySubdomain;
-      fallbackSubdomain = legacySubdomain;
     }
   }
 }


### PR DESCRIPTION
### Description

This PR adds the `X-PagerDuty-Client` header to all PagerDuty API requests made by the backend plugin. The header format follows the specification: `"Backstage" <https://[subdomain].backstage.com>`.

### Implementation Details

- Added subdomain storage mechanism to track account-specific subdomains
- Created `getSubdomain()` helper function to retrieve subdomain with proper fallback logic (account-specific → fallback → default)
- Updated `getDefaultHeaders()` to include the `X-PagerDuty-Client` header with the correct format
- All 14 API functions now use the centralized header configuration
- Supports multi-account configuration with multiple subdomains
- Handles legacy configuration formats

### Affected plugin

- [x] backstage-plugin-backend

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes have been tested in dark theme
- [ ] Changes are documented
- [x] Changes generate _no new warnings_
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

- [x] This PR was code assisted