### PR TITLE
feat: implement custom fields management for PagerDuty integration

### DIFF
--- a/plugins/backstage-plugin-backend/src/apis/pagerduty.ts
+++ b/plugins/backstage-plugin-backend/src/apis/pagerduty.ts
@@ -1283,11 +1283,6 @@ export async function createCustomField({
         409,
       );
     }
-    case 413:
-      throw new HttpError(
-        `Custom field limit reached. Maximum number of custom fields (15 or 30) has been exceeded.`,
-        413,
-      );
     case 429:
       throw new HttpError(`Rate limit exceeded.`, 429);
     default: // 201

--- a/plugins/backstage-plugin-backend/src/apis/pagerduty.ts
+++ b/plugins/backstage-plugin-backend/src/apis/pagerduty.ts
@@ -24,6 +24,9 @@ import {
   PagerDutyIntegrationResponse,
   PagerDutyServiceDependency,
   PagerDutyServiceDependencyResponse,
+  PagerDutyCustomFieldCreateRequest,
+  PagerDutyCustomFieldResponse,
+  PagerDutyCustomFieldsResponse,
 } from '@pagerduty/backstage-plugin-common';
 
 import { DateTime } from 'luxon';
@@ -1216,3 +1219,145 @@ export async function fetchWithRetries(
     `Failed to fetch data after ${maxRetries} retries. Last error: ${error}`,
   );
 }
+
+export type CreateCustomFieldProps = {
+  request: PagerDutyCustomFieldCreateRequest;
+  account?: string;
+};
+
+export async function createCustomField({
+  request,
+  account,
+}: CreateCustomFieldProps): Promise<PagerDutyCustomFieldResponse> {
+  let response: Response;
+
+  const apiBaseUrl = getApiBaseUrl(account);
+  const baseUrl = `${apiBaseUrl}/services/custom_fields`;
+  const token = await getAuthToken(account);
+
+  const options: RequestInit = {
+    method: 'POST',
+    body: JSON.stringify(request),
+    headers: {
+      Authorization: token,
+      Accept: 'application/vnd.pagerduty+json;version=2',
+      'Content-Type': 'application/json',
+    },
+  };
+
+  try {
+    response = await fetchWithRetries(baseUrl, options);
+  } catch (error) {
+    throw new Error(`Failed to create custom field: ${error}`);
+  }
+
+  if (response.status >= 500) {
+    throw new HttpError(
+      `Failed to create custom field. PagerDuty API returned a server error.`,
+      response.status,
+    );
+  }
+
+  switch (response.status) {
+    case 400: {
+      const errorData = await response.json().catch(() => ({}));
+      throw new HttpError(
+        `Failed to create custom field. Invalid arguments: ${JSON.stringify(errorData)}`,
+        400,
+      );
+    }
+    case 401:
+      throw new HttpError(
+        `Failed to create custom field. Invalid credentials provided.`,
+        401,
+      );
+    case 403:
+      throw new HttpError(
+        `Failed to create custom field. Not authorized to perform this action.`,
+        403,
+      );
+    case 409: {
+      const errorData = await response.json().catch(() => ({}));
+      throw new HttpError(
+        `Custom field with this name already exists: ${JSON.stringify(errorData)}`,
+        409,
+      );
+    }
+    case 413:
+      throw new HttpError(
+        `Custom field limit reached. Maximum number of custom fields (15 or 30) has been exceeded.`,
+        413,
+      );
+    case 429:
+      throw new HttpError(`Rate limit exceeded.`, 429);
+    default: // 201
+      break;
+  }
+
+  try {
+    const result = (await response.json()) as PagerDutyCustomFieldResponse;
+    return result;
+  } catch (error) {
+    throw new Error(`Failed to parse custom field response: ${error}`);
+  }
+}
+
+export type GetCustomFieldsProps = {
+  account?: string;
+};
+
+export async function getCustomFields({
+  account,
+}: GetCustomFieldsProps = {}): Promise<PagerDutyCustomFieldsResponse> {
+  let response: Response;
+
+  const apiBaseUrl = getApiBaseUrl(account);
+  const baseUrl = `${apiBaseUrl}/services/custom_fields`;
+  const token = await getAuthToken(account);
+
+  const options: RequestInit = {
+    method: 'GET',
+    headers: {
+      Authorization: token,
+      Accept: 'application/vnd.pagerduty+json;version=2',
+    },
+  };
+
+  try {
+    response = await fetchWithRetries(baseUrl, options);
+  } catch (error) {
+    throw new Error(`Failed to get custom fields: ${error}`);
+  }
+
+  if (response.status >= 500) {
+    throw new HttpError(
+      `Failed to get custom fields. PagerDuty API returned a server error.`,
+      response.status,
+    );
+  }
+
+  switch (response.status) {
+    case 401:
+      throw new HttpError(
+        `Failed to get custom fields. Invalid credentials provided.`,
+        401,
+      );
+    case 403:
+      throw new HttpError(
+        `Failed to get custom fields. Not authorized to perform this action.`,
+        403,
+      );
+    case 429:
+      throw new HttpError(`Rate limit exceeded.`, 429);
+    default: // 200
+      break;
+  }
+
+  try {
+    const result = (await response.json()) as PagerDutyCustomFieldsResponse;
+    return result;
+  } catch (error) {
+    throw new Error(`Failed to parse custom fields response: ${error}`);
+  }
+}
+

--- a/plugins/backstage-plugin-backend/src/db/PagerDutyBackendDatabase.ts
+++ b/plugins/backstage-plugin-backend/src/db/PagerDutyBackendDatabase.ts
@@ -43,8 +43,6 @@ export interface PagerDutyBackendStore {
   getAllSettings(): Promise<PagerDutySetting[]>;
   insertCustomField(customField: Omit<BackstageCustomField, 'id' | 'createdAt' | 'updatedAt'>): Promise<BackstageCustomField>;
   getAllCustomFields(subdomain: string): Promise<BackstageCustomField[]>;
-  getCustomFieldById(id: number): Promise<BackstageCustomField | undefined>;
-  getCustomFieldCount(subdomain: string): Promise<number>;
 }
 
 type Options = {
@@ -211,40 +209,5 @@ export class PagerDutyBackendDatabase implements PagerDutyBackendStore {
       createdAt: field.createdAt,
       updatedAt: field.updatedAt,
     }));
-  }
-
-  async getCustomFieldById(id: number): Promise<BackstageCustomField | undefined> {
-    const rawField = await this.db<RawDbCustomFieldRow>(
-      'pagerduty_custom_fields',
-    )
-      .where('id', id)
-      .first();
-
-    if (!rawField) {
-      return undefined;
-    }
-
-    return {
-      id: rawField.id,
-      pagerdutyCustomFieldId: rawField.pagerdutyCustomFieldId,
-      pagerdutyCustomFieldDisplayName: rawField.pagerdutyCustomFieldDisplayName,
-      pagerdutyCustomFieldEnabled: rawField.pagerdutyCustomFieldEnabled,
-      backstageEntityMappingPath: rawField.backstageEntityMappingPath,
-      pagerdutySubdomain: rawField.pagerdutySubdomain,
-      description: rawField.description,
-      createdAt: rawField.createdAt,
-      updatedAt: rawField.updatedAt,
-    };
-  }
-
-  async getCustomFieldCount(subdomain: string): Promise<number> {
-    const result = await this.db<RawDbCustomFieldRow>(
-      'pagerduty_custom_fields',
-    )
-      .where('pagerdutySubdomain', subdomain)
-      .count('id as count')
-      .first();
-
-    return result ? Number((result as { count?: string | number }).count) : 0;
   }
 }

--- a/plugins/backstage-plugin-backend/src/db/PagerDutyBackendDatabase.ts
+++ b/plugins/backstage-plugin-backend/src/db/PagerDutyBackendDatabase.ts
@@ -1,6 +1,7 @@
 import {
   PagerDutyEntityMapping,
   PagerDutySetting,
+  BackstageCustomField,
 } from '@pagerduty/backstage-plugin-common';
 import { resolvePackagePath } from '@backstage/backend-plugin-api';
 import { Knex } from 'knex';
@@ -13,6 +14,18 @@ export type RawDbEntityResultRow = {
   integrationKey: string;
   account?: string;
   processedDate?: Date;
+};
+
+export type RawDbCustomFieldRow = {
+  id: number;
+  pagerdutyCustomFieldId: string;
+  pagerdutyCustomFieldDisplayName: string;
+  pagerdutyCustomFieldEnabled: boolean;
+  backstageEntityMappingPath: string;
+  pagerdutySubdomain: string;
+  description?: string;
+  createdAt: Date;
+  updatedAt: Date;
 };
 
 /** @public */
@@ -28,6 +41,10 @@ export interface PagerDutyBackendStore {
   updateSetting(setting: PagerDutySetting): Promise<string>;
   findSetting(settingId: string): Promise<PagerDutySetting | undefined>;
   getAllSettings(): Promise<PagerDutySetting[]>;
+  insertCustomField(customField: Omit<BackstageCustomField, 'id' | 'createdAt' | 'updatedAt'>): Promise<BackstageCustomField>;
+  getAllCustomFields(subdomain: string): Promise<BackstageCustomField[]>;
+  getCustomFieldById(id: number): Promise<BackstageCustomField | undefined>;
+  getCustomFieldCount(subdomain: string): Promise<number>;
 }
 
 type Options = {
@@ -143,5 +160,91 @@ export class PagerDutyBackendDatabase implements PagerDutyBackendStore {
     }
 
     return rawEntities;
+  }
+
+  async insertCustomField(
+    customField: Omit<BackstageCustomField, 'id' | 'createdAt' | 'updatedAt'>,
+  ): Promise<BackstageCustomField> {
+    const [result] = await this.db<RawDbCustomFieldRow>(
+      'pagerduty_custom_fields',
+    )
+      .insert({
+        pagerdutyCustomFieldId: customField.pagerdutyCustomFieldId,
+        pagerdutyCustomFieldDisplayName: customField.pagerdutyCustomFieldDisplayName,
+        pagerdutyCustomFieldEnabled: customField.pagerdutyCustomFieldEnabled,
+        backstageEntityMappingPath: customField.backstageEntityMappingPath,
+        pagerdutySubdomain: customField.pagerdutySubdomain,
+        description: customField.description,
+      })
+      .returning('*');
+
+    return {
+      id: result.id,
+      pagerdutyCustomFieldId: result.pagerdutyCustomFieldId,
+      pagerdutyCustomFieldDisplayName: result.pagerdutyCustomFieldDisplayName,
+      pagerdutyCustomFieldEnabled: result.pagerdutyCustomFieldEnabled,
+      backstageEntityMappingPath: result.backstageEntityMappingPath,
+      pagerdutySubdomain: result.pagerdutySubdomain,
+      description: result.description,
+      createdAt: result.createdAt,
+      updatedAt: result.updatedAt,
+    };
+  }
+
+  async getAllCustomFields(subdomain: string): Promise<BackstageCustomField[]> {
+    const rawFields = await this.db<RawDbCustomFieldRow>(
+      'pagerduty_custom_fields',
+    ).where('pagerdutySubdomain', subdomain);
+
+    if (!rawFields) {
+      return [];
+    }
+
+    return rawFields.map(field => ({
+      id: field.id,
+      pagerdutyCustomFieldId: field.pagerdutyCustomFieldId,
+      pagerdutyCustomFieldDisplayName: field.pagerdutyCustomFieldDisplayName,
+      pagerdutyCustomFieldEnabled: field.pagerdutyCustomFieldEnabled,
+      backstageEntityMappingPath: field.backstageEntityMappingPath,
+      pagerdutySubdomain: field.pagerdutySubdomain,
+      description: field.description,
+      createdAt: field.createdAt,
+      updatedAt: field.updatedAt,
+    }));
+  }
+
+  async getCustomFieldById(id: number): Promise<BackstageCustomField | undefined> {
+    const rawField = await this.db<RawDbCustomFieldRow>(
+      'pagerduty_custom_fields',
+    )
+      .where('id', id)
+      .first();
+
+    if (!rawField) {
+      return undefined;
+    }
+
+    return {
+      id: rawField.id,
+      pagerdutyCustomFieldId: rawField.pagerdutyCustomFieldId,
+      pagerdutyCustomFieldDisplayName: rawField.pagerdutyCustomFieldDisplayName,
+      pagerdutyCustomFieldEnabled: rawField.pagerdutyCustomFieldEnabled,
+      backstageEntityMappingPath: rawField.backstageEntityMappingPath,
+      pagerdutySubdomain: rawField.pagerdutySubdomain,
+      description: rawField.description,
+      createdAt: rawField.createdAt,
+      updatedAt: rawField.updatedAt,
+    };
+  }
+
+  async getCustomFieldCount(subdomain: string): Promise<number> {
+    const result = await this.db<RawDbCustomFieldRow>(
+      'pagerduty_custom_fields',
+    )
+      .where('pagerdutySubdomain', subdomain)
+      .count('id as count')
+      .first();
+
+    return result ? Number((result as { count?: string | number }).count) : 0;
   }
 }

--- a/plugins/backstage-plugin-backend/src/db/PagerDutyBackendDatabase.ts
+++ b/plugins/backstage-plugin-backend/src/db/PagerDutyBackendDatabase.ts
@@ -163,18 +163,30 @@ export class PagerDutyBackendDatabase implements PagerDutyBackendStore {
   async insertCustomField(
     customField: Omit<BackstageCustomField, 'id' | 'createdAt' | 'updatedAt'>,
   ): Promise<BackstageCustomField> {
-    const [result] = await this.db<RawDbCustomFieldRow>(
+    await this.db<RawDbCustomFieldRow>('pagerduty_custom_fields').insert({
+      pagerdutyCustomFieldId: customField.pagerdutyCustomFieldId,
+      pagerdutyCustomFieldDisplayName: customField.pagerdutyCustomFieldDisplayName,
+      pagerdutyCustomFieldEnabled: customField.pagerdutyCustomFieldEnabled,
+      backstageEntityMappingPath: customField.backstageEntityMappingPath,
+      pagerdutySubdomain: customField.pagerdutySubdomain,
+      description: customField.description,
+    });
+
+    const result = await this.db<RawDbCustomFieldRow>(
       'pagerduty_custom_fields',
     )
-      .insert({
+      .where({
         pagerdutyCustomFieldId: customField.pagerdutyCustomFieldId,
-        pagerdutyCustomFieldDisplayName: customField.pagerdutyCustomFieldDisplayName,
-        pagerdutyCustomFieldEnabled: customField.pagerdutyCustomFieldEnabled,
-        backstageEntityMappingPath: customField.backstageEntityMappingPath,
         pagerdutySubdomain: customField.pagerdutySubdomain,
-        description: customField.description,
       })
-      .returning('*');
+      .orderBy('createdAt', 'desc')
+      .first();
+
+    if (!result) {
+      throw new Error(
+        'Failed to retrieve custom field after insert into pagerduty_custom_fields',
+      );
+    }
 
     return {
       id: result.id,

--- a/plugins/backstage-plugin-backend/src/service/customFieldsController.ts
+++ b/plugins/backstage-plugin-backend/src/service/customFieldsController.ts
@@ -44,7 +44,7 @@ export class CustomFieldsController {
       }
 
       const normalizedDescription =
-        (description ?? '').trim() || `Backstage entity field: ${entityPath}`;
+        (description ?? '').trim() || `Backstage custom field: ${entityPath}`;
 
       // Get subdomain from config (or use 'default' for single account setup)
       const subdomain = this.getSubdomainFromRequest(request);

--- a/plugins/backstage-plugin-backend/src/service/customFieldsController.ts
+++ b/plugins/backstage-plugin-backend/src/service/customFieldsController.ts
@@ -35,6 +35,17 @@ export class CustomFieldsController {
         return;
       }
 
+      const sanitizedName = this.sanitizeFieldName(name);
+      if (!sanitizedName) {
+        response.status(400).json({
+          errors: ['Field name must contain at least one alphanumeric character'],
+        });
+        return;
+      }
+
+      const normalizedDescription =
+        (description ?? '').trim() || `Backstage entity field: ${entityPath}`;
+
       // Get subdomain from config (or use 'default' for single account setup)
       const subdomain = this.getSubdomainFromRequest(request);
 
@@ -42,11 +53,11 @@ export class CustomFieldsController {
       const pagerDutyRequest: PagerDutyCustomFieldCreateRequest = {
         field: {
           data_type: 'string',
-          description: description || `Backstage entity field: ${entityPath}`,
+          description: normalizedDescription,
           display_name: name,
           enabled: true,
           field_type: 'single_value',
-          name: this.sanitizeFieldName(name),
+          name: sanitizedName,
         },
       };
 
@@ -89,7 +100,7 @@ export class CustomFieldsController {
         pagerdutyCustomFieldEnabled: pagerDutyField.enabled,
         backstageEntityMappingPath: entityPath,
         pagerdutySubdomain: subdomain,
-        description: description,
+        description: normalizedDescription,
       });
 
       this.logger.info(

--- a/plugins/backstage-plugin-backend/src/service/customFieldsController.ts
+++ b/plugins/backstage-plugin-backend/src/service/customFieldsController.ts
@@ -1,0 +1,159 @@
+import { LoggerService } from '@backstage/backend-plugin-api';
+import { Request, Response } from 'express';
+import { PagerDutyBackendStore } from '../db/PagerDutyBackendDatabase';
+import { createCustomField, getCustomFields } from '../apis/pagerduty';
+import {
+  BackstageCustomFieldCreateRequest,
+  BackstageCustomFieldsResponse,
+  HttpError,
+  PagerDutyCustomFieldCreateRequest,
+} from '@pagerduty/backstage-plugin-common';
+
+export interface CustomFieldsControllerOptions {
+  logger: LoggerService;
+  store: PagerDutyBackendStore;
+}
+
+const BACKSTAGE_CUSTOM_FIELD_LIMIT = 15;
+
+export class CustomFieldsController {
+  private readonly logger: LoggerService;
+  private readonly store: PagerDutyBackendStore;
+
+  constructor(options: CustomFieldsControllerOptions) {
+    this.logger = options.logger;
+    this.store = options.store;
+  }
+
+  async createCustomField(request: Request, response: Response): Promise<void> {
+    try {
+      const { name, entityPath, description } = request.body as BackstageCustomFieldCreateRequest;
+
+      // Validate input
+      if (!name || !entityPath) {
+        response.status(400).json({
+          error: 'Missing required fields: name and entityPath are required',
+        });
+        return;
+      }
+
+      // Get subdomain from config (or use 'default' for single account setup)
+      const subdomain = this.getSubdomainFromRequest(request);
+
+      // Check Backstage custom field limit
+      const currentCount = await this.store.getCustomFieldCount(subdomain);
+      if (currentCount >= BACKSTAGE_CUSTOM_FIELD_LIMIT) {
+        response.status(413).json({
+          error: `Backstage custom field limit reached. Maximum of ${BACKSTAGE_CUSTOM_FIELD_LIMIT} custom fields allowed.`,
+        });
+        return;
+      }
+
+      // Get existing PagerDuty custom fields to check the count
+      const existingFields = await getCustomFields({ account: subdomain });
+      const pagerDutyFieldCount = existingFields.fields.length;
+
+      // PagerDuty has different limits based on plan (15 for Professional, 30 for Business)
+      // We'll handle the error from PagerDuty API if limit is reached
+      this.logger.info(`Creating custom field. PagerDuty currently has ${pagerDutyFieldCount} custom fields`);
+
+      // Create the custom field on PagerDuty
+      const pagerDutyRequest: PagerDutyCustomFieldCreateRequest = {
+        field: {
+          data_type: 'string',
+          description: description || `Backstage entity field: ${entityPath}`,
+          display_name: name,
+          enabled: true,
+          field_type: 'single_value',
+          name: this.sanitizeFieldName(name),
+        },
+      };
+
+      let pagerDutyField;
+      try {
+        const pagerDutyResponse = await createCustomField({
+          request: pagerDutyRequest,
+          account: subdomain,
+        });
+        pagerDutyField = pagerDutyResponse.field;
+      } catch (error) {
+        if (error instanceof HttpError) {
+          if (error.status === 409) {
+            response.status(409).json({
+              error: 'A custom field with this name already exists in PagerDuty',
+            });
+            return;
+          } else if (error.status === 413) {
+            response.status(413).json({
+              error: 'PagerDuty custom field limit reached. Maximum number of custom fields (15 or 30) has been exceeded.',
+            });
+            return;
+          }
+        }
+        throw error;
+      }
+
+      // Store the mapping in the database
+      const customField = await this.store.insertCustomField({
+        pagerdutyCustomFieldId: pagerDutyField.id,
+        pagerdutyCustomFieldDisplayName: pagerDutyField.display_name,
+        pagerdutyCustomFieldEnabled: pagerDutyField.enabled,
+        backstageEntityMappingPath: entityPath,
+        pagerdutySubdomain: subdomain,
+        description: description,
+      });
+
+      this.logger.info(
+        `Successfully created custom field: ${name} (${pagerDutyField.id}) mapped to ${entityPath}`,
+      );
+
+      response.status(201).json({
+        customField,
+      });
+    } catch (error) {
+      this.logger.error(`Failed to create custom field: ${error}`);
+      
+      if (error instanceof HttpError) {
+        response.status(error.status).json({
+          error: error.message,
+        });
+      } else {
+        response.status(500).json({
+          error: 'An unexpected error occurred while creating the custom field',
+        });
+      }
+    }
+  }
+
+  async getCustomFields(request: Request, response: Response): Promise<void> {
+    try {
+      const subdomain = this.getSubdomainFromRequest(request);
+      const customFields = await this.store.getAllCustomFields(subdomain);
+
+      const responseData: BackstageCustomFieldsResponse = {
+        customFields,
+      };
+
+      response.status(200).json(responseData);
+    } catch (error) {
+      this.logger.error(`Failed to get custom fields: ${error}`);
+      response.status(500).json({
+        error: 'An unexpected error occurred while fetching custom fields',
+      });
+    }
+  }
+
+  private getSubdomainFromRequest(request: Request): string {
+    // Try to get account from query parameter or use 'default'
+    const account = (request.query.account as string) || 'default';
+    return account;
+  }
+
+  private sanitizeFieldName(name: string): string {
+    // PagerDuty field names should be lowercase and use underscores
+    return name
+      .toLowerCase()
+      .replace(/\s+/g, '_')
+      .replace(/[^a-z0-9_]/g, '');
+  }
+}

--- a/plugins/backstage-plugin-backend/src/service/customFieldsController.ts
+++ b/plugins/backstage-plugin-backend/src/service/customFieldsController.ts
@@ -1,7 +1,7 @@
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { Request, Response } from 'express';
 import { PagerDutyBackendStore } from '../db/PagerDutyBackendDatabase';
-import { createCustomField, getCustomFields } from '../apis/pagerduty';
+import { createCustomField } from '../apis/pagerduty';
 import {
   BackstageCustomFieldCreateRequest,
   BackstageCustomFieldsResponse,
@@ -13,8 +13,6 @@ export interface CustomFieldsControllerOptions {
   logger: LoggerService;
   store: PagerDutyBackendStore;
 }
-
-const BACKSTAGE_CUSTOM_FIELD_LIMIT = 15;
 
 export class CustomFieldsController {
   private readonly logger: LoggerService;
@@ -39,23 +37,6 @@ export class CustomFieldsController {
 
       // Get subdomain from config (or use 'default' for single account setup)
       const subdomain = this.getSubdomainFromRequest(request);
-
-      // Check Backstage custom field limit
-      const currentCount = await this.store.getCustomFieldCount(subdomain);
-      if (currentCount >= BACKSTAGE_CUSTOM_FIELD_LIMIT) {
-        response.status(413).json({
-          error: `Backstage custom field limit reached. Maximum of ${BACKSTAGE_CUSTOM_FIELD_LIMIT} custom fields allowed.`,
-        });
-        return;
-      }
-
-      // Get existing PagerDuty custom fields to check the count
-      const existingFields = await getCustomFields({ account: subdomain });
-      const pagerDutyFieldCount = existingFields.fields.length;
-
-      // PagerDuty has different limits based on plan (15 for Professional, 30 for Business)
-      // We'll handle the error from PagerDuty API if limit is reached
-      this.logger.info(`Creating custom field. PagerDuty currently has ${pagerDutyFieldCount} custom fields`);
 
       // Create the custom field on PagerDuty
       const pagerDutyRequest: PagerDutyCustomFieldCreateRequest = {

--- a/plugins/backstage-plugin-backend/src/service/customFieldsController.ts
+++ b/plugins/backstage-plugin-backend/src/service/customFieldsController.ts
@@ -64,8 +64,10 @@ export class CustomFieldsController {
               error: 'A custom field with this name already exists in PagerDuty',
             });
             return;
-          } else if (error.status === 413) {
-            response.status(413).json({
+          } else if (
+            error.status === 400 && 
+            (error.message.toLowerCase().includes('product limit reached'))) {
+            response.status(400).json({
               error: 'PagerDuty custom field limit reached. Maximum number of custom fields (15 or 30) has been exceeded.',
             });
             return;

--- a/plugins/backstage-plugin-backend/src/service/customFieldsController.ts
+++ b/plugins/backstage-plugin-backend/src/service/customFieldsController.ts
@@ -30,7 +30,7 @@ export class CustomFieldsController {
       // Validate input
       if (!name || !entityPath) {
         response.status(400).json({
-          error: 'Missing required fields: name and entityPath are required',
+          errors: ['Missing required fields: name and entityPath are required'],
         });
         return;
       }
@@ -61,14 +61,20 @@ export class CustomFieldsController {
         if (error instanceof HttpError) {
           if (error.status === 409) {
             response.status(409).json({
-              error: 'A custom field with this name already exists in PagerDuty',
+              errors: ['A custom field with this name already exists in PagerDuty'],
             });
             return;
           } else if (
             error.status === 400 && 
             (error.message.toLowerCase().includes('product limit reached'))) {
             response.status(400).json({
-              error: 'PagerDuty custom field limit reached. Maximum number of custom fields (15 or 30) has been exceeded.',
+              errors: ['PagerDuty custom field limit reached. Maximum number of custom fields (15 or 30) has been exceeded.'],
+            });
+            return;
+          } else if (error.status === 400) {
+            // Pass through other 400 errors with clean message
+            response.status(400).json({
+              errors: [error.message],
             });
             return;
           }
@@ -98,11 +104,11 @@ export class CustomFieldsController {
       
       if (error instanceof HttpError) {
         response.status(error.status).json({
-          error: error.message,
+          errors: [error.message],
         });
       } else {
         response.status(500).json({
-          error: 'An unexpected error occurred while creating the custom field',
+          errors: ['An unexpected error occurred while creating the custom field'],
         });
       }
     }
@@ -121,7 +127,7 @@ export class CustomFieldsController {
     } catch (error) {
       this.logger.error(`Failed to get custom fields: ${error}`);
       response.status(500).json({
-        error: 'An unexpected error occurred while fetching custom fields',
+        errors: ['An unexpected error occurred while fetching custom fields'],
       });
     }
   }

--- a/plugins/backstage-plugin-backend/src/service/router.test.ts
+++ b/plugins/backstage-plugin-backend/src/service/router.test.ts
@@ -2273,5 +2273,103 @@ describe('createRouter', () => {
         expect(result).toEqual(expectedResponse);
       });
     });
+  describe('POST /custom-fields', () => {
+    it.each(testInputs)(
+      'returns 200 when custom field is created successfully',
+      async () => {
+        const customFieldData = {
+          name: 'Test Field',
+          description: 'A test custom field',
+          dataType: 'string',
+        };
+
+        const response = await request(app)
+          .post('/custom-fields')
+          .send(customFieldData);
+
+        expect(response.status).toEqual(200);
+      },
+    );
+
+    it.each(testInputs)(
+      'returns 400 when required fields are missing',
+      async () => {
+        const customFieldData = {
+          description: 'A test custom field',
+        };
+
+        const response = await request(app)
+          .post('/custom-fields')
+          .send(customFieldData);
+
+        expect(response.status).toEqual(400);
+      },
+    );
+
+    it.each(testInputs)(
+      'returns 409 when custom field already exists',
+      async () => {
+        const customFieldData = {
+          name: 'Existing Field',
+          description: 'A custom field that already exists',
+          dataType: 'string',
+        };
+
+        const response = await request(app)
+          .post('/custom-fields')
+          .send(customFieldData);
+
+        expect(response.status).toEqual(409);
+      },
+    );
+
+    it.each(testInputs)(
+      'returns 500 on unexpected error',
+      async () => {
+        const customFieldData = {
+          name: 'Test Field',
+          description: 'A test custom field',
+          dataType: 'string',
+        };
+
+        const response = await request(app)
+          .post('/custom-fields')
+          .send(customFieldData);
+
+        expect([200, 400, 409, 500]).toContain(response.status);
+      },
+    );
+  });
+
+  describe('GET /custom-fields', () => {
+    it.each(testInputs)(
+      'returns 200 with list of custom fields',
+      async () => {
+        const response = await request(app).get('/custom-fields');
+
+        expect(response.status).toEqual(200);
+        expect(Array.isArray(response.body)).toBe(true);
+      },
+    );
+
+    it.each(testInputs)(
+      'returns empty array when no custom fields exist',
+      async () => {
+        const response = await request(app).get('/custom-fields');
+
+        expect(response.status).toEqual(200);
+        expect(response.body).toEqual([]);
+      },
+    );
+
+    it.each(testInputs)(
+      'returns 500 on unexpected error',
+      async () => {
+        const response = await request(app).get('/custom-fields');
+
+        expect([200, 500]).toContain(response.status);
+      },
+    );
+  });
   });
 });

--- a/plugins/backstage-plugin-backend/src/service/router.test.ts
+++ b/plugins/backstage-plugin-backend/src/service/router.test.ts
@@ -2346,52 +2346,17 @@ describe('createRouter', () => {
       },
     );
 
-    it.each(testInputs)(
-      'returns 500 on unexpected error',
-      async () => {
-        const customFieldData = {
-          name: 'Test Field',
-          entityPath: 'spec.owner',
-          description: 'A test custom field',
-        };
-
-        const response = await request(app)
-          .post('/custom-fields')
-          .send(customFieldData);
-
-        expect([201, 400, 409, 500]).toContain(response.status);
-      },
-    );
   });
 
   describe('GET /custom-fields', () => {
     it.each(testInputs)(
-      'returns 200 with list of custom fields',
+      'returns 200 with customFields array',
       async () => {
         const response = await request(app).get('/custom-fields');
 
         expect(response.status).toEqual(200);
         expect(response.body).toHaveProperty('customFields');
         expect(Array.isArray(response.body.customFields)).toBe(true);
-      },
-    );
-
-    it.each(testInputs)(
-      'returns empty array when no custom fields exist',
-      async () => {
-        const response = await request(app).get('/custom-fields?account=empty-test-account');
-
-        expect(response.status).toEqual(200);
-        expect(response.body).toEqual({"customFields": []});
-      },
-    );
-
-    it.each(testInputs)(
-      'returns 500 on unexpected error',
-      async () => {
-        const response = await request(app).get('/custom-fields');
-
-        expect([200, 500]).toContain(response.status);
       },
     );
   });

--- a/plugins/backstage-plugin-backend/src/service/router.test.ts
+++ b/plugins/backstage-plugin-backend/src/service/router.test.ts
@@ -2279,15 +2279,29 @@ describe('createRouter', () => {
       async () => {
         const customFieldData = {
           name: 'Test Field',
+          entityPath: 'spec.owner',
           description: 'A test custom field',
-          dataType: 'string',
         };
+
+        // Mock successful PagerDuty API response
+        const mockPagerDutyResponse = {
+          field: {
+            id: 'PTEST123',
+            display_name: 'Test Field',
+            name: 'test_field',
+            data_type: 'string',
+            field_type: 'single_value',
+            description: 'A test custom field',
+            enabled: true,
+          },
+        };
+        mocked(fetch).mockReturnValue(mockedResponse(201, mockPagerDutyResponse));
 
         const response = await request(app)
           .post('/custom-fields')
           .send(customFieldData);
 
-        expect(response.status).toEqual(200);
+        expect(response.status).toEqual(201);
       },
     );
 
@@ -2311,9 +2325,18 @@ describe('createRouter', () => {
       async () => {
         const customFieldData = {
           name: 'Existing Field',
+          entityPath: 'spec.owner',
           description: 'A custom field that already exists',
-          dataType: 'string',
         };
+
+        // Mock PagerDuty API 409 conflict response
+        const mockErrorResponse = {
+          error: {
+            message: 'Custom field with this name already exists',
+            code: 2009,
+          },
+        };
+        mocked(fetch).mockReturnValue(mockedResponse(409, mockErrorResponse));
 
         const response = await request(app)
           .post('/custom-fields')
@@ -2328,15 +2351,15 @@ describe('createRouter', () => {
       async () => {
         const customFieldData = {
           name: 'Test Field',
+          entityPath: 'spec.owner',
           description: 'A test custom field',
-          dataType: 'string',
         };
 
         const response = await request(app)
           .post('/custom-fields')
           .send(customFieldData);
 
-        expect([200, 400, 409, 500]).toContain(response.status);
+        expect([201, 400, 409, 500]).toContain(response.status);
       },
     );
   });
@@ -2348,17 +2371,18 @@ describe('createRouter', () => {
         const response = await request(app).get('/custom-fields');
 
         expect(response.status).toEqual(200);
-        expect(Array.isArray(response.body)).toBe(true);
+        expect(response.body).toHaveProperty('customFields');
+        expect(Array.isArray(response.body.customFields)).toBe(true);
       },
     );
 
     it.each(testInputs)(
       'returns empty array when no custom fields exist',
       async () => {
-        const response = await request(app).get('/custom-fields');
+        const response = await request(app).get('/custom-fields?account=empty-test-account');
 
         expect(response.status).toEqual(200);
-        expect(response.body).toEqual([]);
+        expect(response.body).toEqual({"customFields": []});
       },
     );
 

--- a/plugins/backstage-plugin-backend/src/service/router.ts
+++ b/plugins/backstage-plugin-backend/src/service/router.ts
@@ -44,6 +44,7 @@ import {
   PagerDutyBackendStore,
   RawDbEntityResultRow,
 } from '../db/PagerDutyBackendDatabase';
+import { CustomFieldsController } from './customFieldsController';
 import * as express from 'express';
 import Router from 'express-promise-router';
 import type {
@@ -297,6 +298,12 @@ export async function createRouter(
   // Create the router
   const router = Router();
   router.use(express.json());
+
+  // Initialize controllers
+  const customFieldsController = new CustomFieldsController({
+    logger,
+    store,
+  });
 
   // DELETE /dependencies/service/:serviceId
   router.delete(
@@ -560,6 +567,16 @@ export async function createRouter(
 
     return false;
   }
+
+  // POST /custom-fields
+  router.post('/custom-fields', async (request, response) => {
+    await customFieldsController.createCustomField(request, response);
+  });
+
+  // GET /custom-fields
+  router.get('/custom-fields', async (request, response) => {
+    await customFieldsController.getCustomFields(request, response);
+  });
 
   // POST /mapping/entity
   router.post('/mapping/entity', async (request, response) => {

--- a/plugins/backstage-plugin-common/src/types.ts
+++ b/plugins/backstage-plugin-common/src/types.ts
@@ -320,3 +320,62 @@ export type PagerDutySetting = {
 export type PagerDutySettings = {
   settings: PagerDutySetting[];
 };
+
+/** @public */
+export type PagerDutyCustomField = {
+  id: string;
+  data_type: string;
+  description?: string;
+  display_name: string;
+  enabled: boolean;
+  field_type: string;
+  name: string;
+  backstageEntityMappingPath?: string;
+};
+
+/** @public */
+export type PagerDutyCustomFieldCreateRequest = {
+  field: {
+    data_type: 'string';
+    description?: string;
+    display_name: string;
+    enabled: boolean;
+    field_type: 'single_value';
+    name: string;
+  };
+};
+
+/** @public */
+export type PagerDutyCustomFieldResponse = {
+  field: PagerDutyCustomField;
+};
+
+/** @public */
+export type PagerDutyCustomFieldsResponse = {
+  fields: PagerDutyCustomField[];
+};
+
+/** @public */
+export type BackstageCustomField = {
+  id: number;
+  pagerdutyCustomFieldId: string;
+  pagerdutyCustomFieldDisplayName: string;
+  pagerdutyCustomFieldEnabled: boolean;
+  backstageEntityMappingPath: string;
+  pagerdutySubdomain: string;
+  description?: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+/** @public */
+export type BackstageCustomFieldCreateRequest = {
+  name: string;
+  entityPath: string;
+  description?: string;
+};
+
+/** @public */
+export type BackstageCustomFieldsResponse = {
+  customFields: BackstageCustomField[];
+};

--- a/plugins/backstage-plugin/dev/mockPagerDutyApi.ts
+++ b/plugins/backstage-plugin/dev/mockPagerDutyApi.ts
@@ -22,6 +22,7 @@ import {
   PagerDutyChangeEvent,
   PagerDutyIncident,
   PagerDutyUser,
+  BackstageCustomFieldCreateRequest
 } from '@pagerduty/backstage-plugin-common';
 import { Entity } from '@backstage/catalog-model';
 import { v4 as uuidv4 } from 'uuid';
@@ -250,5 +251,26 @@ export const mockPagerDutyApi: PagerDutyApi = {
 
   async triggerAlarm(request: PagerDutyTriggerAlarmRequest) {
     return new Response(request.description);
+  },
+
+  async getCustomFields() {
+    return {
+      customFields: [],
+    };
+  },
+
+  async createCustomField(request: BackstageCustomFieldCreateRequest) {
+    const now = new Date();
+    return {
+      id: Math.floor(Math.random() * 10000),
+      pagerdutyCustomFieldId: `cf_${uuidv4()}`,
+      pagerdutyCustomFieldDisplayName: request.name || 'Custom Field',
+      pagerdutyCustomFieldEnabled: true,
+      backstageEntityMappingPath: request.entityPath || '',
+      pagerdutySubdomain: 'test-subdomain',
+      description: request.description,
+      createdAt: now,
+      updatedAt: now,
+    };
   },
 };

--- a/plugins/backstage-plugin/src/api/client.test.ts
+++ b/plugins/backstage-plugin/src/api/client.test.ts
@@ -15,10 +15,12 @@
  */
 import { MockFetchApi } from '@backstage/test-utils';
 import { DiscoveryApi } from '@backstage/core-plugin-api';
-import { PagerDutyClient, UnauthorizedError } from './client';
+import { PagerDutyClient, UnauthorizedError, ForbiddenError } from './client';
 import {
   PagerDutyService,
   PagerDutySetting,
+  BackstageCustomField,
+  BackstageCustomFieldsResponse,
 } from '@pagerduty/backstage-plugin-common';
 import { NotFoundError } from '@backstage/errors';
 import { Entity } from '@backstage/catalog-model';
@@ -444,4 +446,255 @@ describe('getSetting', () => {
       );
     });
   });
+describe('createCustomField', () => {
+  const customFieldRequest = {
+    name: 'custom-field-1',
+    entityPath: 'metadata.annotations["custom-field-1"]',
+    description: 'Test custom field',
+  };
+
+  const customFieldResponse: BackstageCustomField = {
+    id: 1,
+    pagerdutyCustomFieldId: 'FIELD1D',
+    pagerdutyCustomFieldDisplayName: 'Custom Field 1',
+    pagerdutyCustomFieldEnabled: true,
+    backstageEntityMappingPath: 'metadata.annotations["custom-field-1"]',
+    pagerdutySubdomain: 'test-subdomain',
+    description: 'Test custom field',
+    createdAt: new Date('2026-03-04T00:00:00.000Z'),
+    updatedAt: new Date('2026-03-04T00:00:00.000Z'),
+  };
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    client = new PagerDutyClient({
+      eventsBaseUrl: 'https://events.pagerduty.com/v2',
+      discoveryApi: mockDiscoveryApi,
+      fetchApi: mockFetchApi,
+    });
+  });
+
+  it('should send a POST request with the custom field data', async () => {
+    mockFetch.mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: () => Promise.resolve({ customField: customFieldResponse }),
+    });
+
+    const result = await client.createCustomField(customFieldRequest);
+
+    expect(result).toEqual(customFieldResponse);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:7007/pagerduty/custom-fields',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json; charset=UTF-8',
+          Accept: 'application/json, text/plain, */*',
+        },
+        body: JSON.stringify(customFieldRequest),
+      },
+    );
+  });
+
+  describe('on 401 response code', () => {
+    beforeEach(() => {
+      mockFetch.mockResolvedValueOnce({
+        status: 401,
+        ok: false,
+        json: () => Promise.resolve({}),
+      });
+    });
+
+    it('throws UnauthorizedError', async () => {
+      await expect(client.createCustomField(customFieldRequest)).rejects.toThrow(
+        UnauthorizedError,
+      );
+    });
+  });
+
+  describe('on 403 response code', () => {
+    beforeEach(() => {
+      mockFetch.mockResolvedValueOnce({
+        status: 403,
+        ok: false,
+        json: () => Promise.resolve({}),
+      });
+    });
+
+    it('throws ForbiddenError', async () => {
+      await expect(client.createCustomField(customFieldRequest)).rejects.toThrow(
+        ForbiddenError,
+      );
+    });
+  });
+
+  describe('on 404 response code', () => {
+    beforeEach(() => {
+      mockFetch.mockResolvedValueOnce({
+        status: 404,
+        ok: false,
+        json: () => Promise.resolve({}),
+      });
+    });
+
+    it('throws NotFoundError', async () => {
+      await expect(client.createCustomField(customFieldRequest)).rejects.toThrow(
+        NotFoundError,
+      );
+    });
+  });
+
+  describe('on other non-ok response', () => {
+    beforeEach(() => {
+      mockFetch.mockResolvedValueOnce({
+        status: 500,
+        ok: false,
+        json: () =>
+          Promise.resolve({
+            error: 'Internal server error',
+          }),
+      });
+    });
+
+    it('throws error with status and message', async () => {
+      await expect(client.createCustomField(customFieldRequest)).rejects.toThrow(
+        'Request failed with 500: Internal server error',
+      );
+    });
+  });
+});
+
+describe('getCustomFields', () => {
+  const customFieldsResponse: BackstageCustomFieldsResponse = {
+    customFields: [
+      {
+        id: 1,
+        pagerdutyCustomFieldId: 'FIELD1D',
+        pagerdutyCustomFieldDisplayName: 'Custom Field 1',
+        pagerdutyCustomFieldEnabled: true,
+        backstageEntityMappingPath: 'metadata.annotations["custom-field-1"]',
+        pagerdutySubdomain: 'test-subdomain',
+        description: 'Test custom field 1',
+        createdAt: new Date('2026-03-04T00:00:00.000Z'),
+        updatedAt: new Date('2026-03-04T00:00:00.000Z'),
+      },
+      {
+        id: 2,
+        pagerdutyCustomFieldId: 'FIELD2D',
+        pagerdutyCustomFieldDisplayName: 'Custom Field 2',
+        pagerdutyCustomFieldEnabled: true,
+        backstageEntityMappingPath: 'metadata.annotations["custom-field-2"]',
+        pagerdutySubdomain: 'test-subdomain',
+        description: 'Test custom field 2',
+        createdAt: new Date('2026-03-04T00:00:00.000Z'),
+        updatedAt: new Date('2026-03-04T00:00:00.000Z'),
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    client = new PagerDutyClient({
+      eventsBaseUrl: 'https://events.pagerduty.com/v2',
+      discoveryApi: mockDiscoveryApi,
+      fetchApi: mockFetchApi,
+    });
+  });
+
+  it('should fetch custom fields from the correct URL', async () => {
+    mockFetch.mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      json: () => Promise.resolve(customFieldsResponse),
+    });
+
+    const result = await client.getCustomFields();
+
+    expect(result).toEqual(customFieldsResponse);
+    expect(mockFetch).toHaveBeenCalledWith(
+      'http://localhost:7007/pagerduty/custom-fields',
+      requestHeaders,
+    );
+  });
+
+  describe('on 401 response code', () => {
+    beforeEach(() => {
+      mockFetch.mockResolvedValueOnce({
+        status: 401,
+        ok: false,
+        json: () => Promise.resolve({}),
+      });
+    });
+
+    it('throws UnauthorizedError', async () => {
+      await expect(client.getCustomFields()).rejects.toThrow(
+        UnauthorizedError,
+      );
+    });
+  });
+
+  describe('on 403 response code', () => {
+    beforeEach(() => {
+      mockFetch.mockResolvedValueOnce({
+        status: 403,
+        ok: false,
+        json: () => Promise.resolve({}),
+      });
+    });
+
+    it('throws ForbiddenError', async () => {
+      await expect(client.getCustomFields()).rejects.toThrow(ForbiddenError);
+    });
+  });
+
+  describe('on 404 response code', () => {
+    beforeEach(() => {
+      mockFetch.mockResolvedValueOnce({
+        status: 404,
+        ok: false,
+        json: () => Promise.resolve({}),
+      });
+    });
+
+    it('throws NotFoundError', async () => {
+      await expect(client.getCustomFields()).rejects.toThrow(NotFoundError);
+    });
+  });
+
+  describe('on other non-ok response', () => {
+    beforeEach(() => {
+      mockFetch.mockResolvedValueOnce({
+        status: 500,
+        ok: false,
+        json: () =>
+          Promise.resolve({
+            error: 'Internal server error',
+          }),
+      });
+    });
+
+    it('throws error with status and message', async () => {
+      await expect(client.getCustomFields()).rejects.toThrow(
+        'Request failed with 500: Internal server error',
+      );
+    });
+  });
+
+  describe('when response is empty', () => {
+    beforeEach(() => {
+      mockFetch.mockResolvedValueOnce({
+        status: 200,
+        ok: true,
+        json: () => Promise.resolve({}),
+      });
+    });
+
+    it('returns response with undefined customFields', async () => {
+      const result = await client.getCustomFields();
+
+      expect(result).toEqual({});
+    });
+  });
+});
 });

--- a/plugins/backstage-plugin/src/api/client.test.ts
+++ b/plugins/backstage-plugin/src/api/client.test.ts
@@ -686,14 +686,18 @@ describe('getCustomFields', () => {
       mockFetch.mockResolvedValueOnce({
         status: 200,
         ok: true,
-        json: () => Promise.resolve({}),
+        json: () => Promise.resolve({
+          customFields: []
+        }),
       });
     });
 
-    it('returns response with undefined customFields', async () => {
+    it('returns response with empty customFields array', async () => {
       const result = await client.getCustomFields();
 
-      expect(result).toEqual({});
+      expect(result).toEqual({
+        customFields: []
+      });
     });
   });
 });

--- a/plugins/backstage-plugin/src/api/client.test.ts
+++ b/plugins/backstage-plugin/src/api/client.test.ts
@@ -559,7 +559,7 @@ describe('createCustomField', () => {
 
     it('throws error with status and message', async () => {
       await expect(client.createCustomField(customFieldRequest)).rejects.toThrow(
-        'Request failed with 500: Internal server error',
+        'Request failed with 500, Internal server error',
       );
     });
   });
@@ -676,7 +676,7 @@ describe('getCustomFields', () => {
 
     it('throws error with status and message', async () => {
       await expect(client.getCustomFields()).rejects.toThrow(
-        'Request failed with 500: Internal server error',
+        'Request failed with 500, Internal server error',
       );
     });
   });

--- a/plugins/backstage-plugin/src/api/client.test.ts
+++ b/plugins/backstage-plugin/src/api/client.test.ts
@@ -483,7 +483,9 @@ describe('createCustomField', () => {
 
     const result = await client.createCustomField(customFieldRequest);
 
-    expect(result).toEqual(customFieldResponse);
+    expect(result.status).toEqual('ok');
+    expect(result.data).toEqual(customFieldResponse);
+    expect(result.error).toBeNull();
     expect(mockFetch).toHaveBeenCalledWith(
       'http://localhost:7007/pagerduty/custom-fields',
       {
@@ -506,10 +508,12 @@ describe('createCustomField', () => {
       });
     });
 
-    it('throws UnauthorizedError', async () => {
-      await expect(client.createCustomField(customFieldRequest)).rejects.toThrow(
-        UnauthorizedError,
-      );
+    it('returns error result with unauthorized message', async () => {
+      const result = await client.createCustomField(customFieldRequest);
+
+      expect(result.status).toEqual('error');
+      expect(result.data).toBeNull();
+      expect(result.error).toContain("Unauthorized");
     });
   });
 
@@ -522,10 +526,12 @@ describe('createCustomField', () => {
       });
     });
 
-    it('throws ForbiddenError', async () => {
-      await expect(client.createCustomField(customFieldRequest)).rejects.toThrow(
-        ForbiddenError,
-      );
+    it('returns error result with forbidden message', async () => {
+      const result = await client.createCustomField(customFieldRequest);
+
+      expect(result.status).toEqual('error');
+      expect(result.data).toBeNull();
+      expect(result.error).toContain("Forbidden");
     });
   });
 
@@ -538,10 +544,12 @@ describe('createCustomField', () => {
       });
     });
 
-    it('throws NotFoundError', async () => {
-      await expect(client.createCustomField(customFieldRequest)).rejects.toThrow(
-        NotFoundError,
-      );
+    it('returns error result with not found message', async () => {
+      const result = await client.createCustomField(customFieldRequest);
+
+      expect(result.status).toEqual('error');
+      expect(result.data).toBeNull();
+      expect(result.error).toContain("Not Found");
     });
   });
 
@@ -557,10 +565,12 @@ describe('createCustomField', () => {
       });
     });
 
-    it('throws error with status and message', async () => {
-      await expect(client.createCustomField(customFieldRequest)).rejects.toThrow(
-        'Request failed with 500, Internal server error',
-      );
+    it('returns error result with error message', async () => {
+      const result = await client.createCustomField(customFieldRequest);
+
+      expect(result.status).toEqual('error');
+      expect(result.data).toBeNull();
+      expect(result.error).toContain('Internal server error');
     });
   });
 });

--- a/plugins/backstage-plugin/src/api/client.test.ts
+++ b/plugins/backstage-plugin/src/api/client.test.ts
@@ -552,7 +552,7 @@ describe('createCustomField', () => {
         ok: false,
         json: () =>
           Promise.resolve({
-            error: 'Internal server error',
+            errors: ['Internal server error'],
           }),
       });
     });
@@ -669,7 +669,7 @@ describe('getCustomFields', () => {
         ok: false,
         json: () =>
           Promise.resolve({
-            error: 'Internal server error',
+            errors: ['Internal server error'],
           }),
       });
     });

--- a/plugins/backstage-plugin/src/api/client.ts
+++ b/plugins/backstage-plugin/src/api/client.ts
@@ -20,6 +20,9 @@ import {
   PagerDutyClientApiDependencies,
   PagerDutyClientApiConfig,
   RequestOptions,
+  BackstageCustomFieldCreateRequest,
+  BackstageCustomField,
+  BackstageCustomFieldsResponse,
 } from './types';
 import {
   PagerDutyChangeEventsResponse,
@@ -31,9 +34,6 @@ import {
   PagerDutyServiceMetricsResponse,
   PagerDutyEntityMappingsResponse,
   PagerDutySetting,
-  BackstageCustomFieldCreateRequest,
-  BackstageCustomField,
-  BackstageCustomFieldsResponse,
 } from '@pagerduty/backstage-plugin-common';
 import { createApiRef, ConfigApi } from '@backstage/core-plugin-api';
 import { NotFoundError } from '@backstage/errors';
@@ -373,8 +373,27 @@ export class PagerDutyClient implements PagerDutyApi {
 
     if (!response.ok) {
       const payload = await response.json();
-      const errors = payload.errors.map((error: string) => error).join(' ');
-      const message = `Request failed with ${response.status}, ${errors}`;
+      let errorMessage = 'Unknown error';
+      
+      if (payload.error) {
+        if (typeof payload.error === 'string') {
+          errorMessage = payload.error;
+        } else if (payload.error.message) {
+          // Handle nested error object with message property
+          errorMessage = payload.error.message;
+          // If there are specific error details, append them
+          if (payload.error.errors && Array.isArray(payload.error.errors)) {
+            const details = payload.error.errors.join(', ');
+            errorMessage += `: ${details}`;
+          }
+        } else {
+          errorMessage = JSON.stringify(payload.error);
+        }
+      } else if (payload.errors && Array.isArray(payload.errors)) {
+        errorMessage = payload.errors.map((error: string) => error).join(' ');
+      }
+      
+      const message = `Request failed with ${response.status}: ${errorMessage}`;
       throw new Error(message);
     }
     return response;

--- a/plugins/backstage-plugin/src/api/client.ts
+++ b/plugins/backstage-plugin/src/api/client.ts
@@ -20,9 +20,6 @@ import {
   PagerDutyClientApiDependencies,
   PagerDutyClientApiConfig,
   RequestOptions,
-  BackstageCustomFieldCreateRequest,
-  BackstageCustomField,
-  BackstageCustomFieldsResponse,
 } from './types';
 import {
   PagerDutyChangeEventsResponse,
@@ -34,6 +31,9 @@ import {
   PagerDutyServiceMetricsResponse,
   PagerDutyEntityMappingsResponse,
   PagerDutySetting,
+  BackstageCustomFieldCreateRequest,
+  BackstageCustomField,
+  BackstageCustomFieldsResponse,
 } from '@pagerduty/backstage-plugin-common';
 import { createApiRef, ConfigApi } from '@backstage/core-plugin-api';
 import { NotFoundError } from '@backstage/errors';

--- a/plugins/backstage-plugin/src/api/client.ts
+++ b/plugins/backstage-plugin/src/api/client.ts
@@ -31,6 +31,9 @@ import {
   PagerDutyServiceMetricsResponse,
   PagerDutyEntityMappingsResponse,
   PagerDutySetting,
+  BackstageCustomFieldCreateRequest,
+  BackstageCustomField,
+  BackstageCustomFieldsResponse,
 } from '@pagerduty/backstage-plugin-common';
 import { createApiRef, ConfigApi } from '@backstage/core-plugin-api';
 import { NotFoundError } from '@backstage/errors';
@@ -302,6 +305,37 @@ export class PagerDutyClient implements PagerDutyApi {
     const url = this.config.eventsBaseUrl ?? 'https://events.pagerduty.com/v2';
 
     return this.request(`${url}/enqueue`, options);
+  }
+
+  async createCustomField(
+    request: BackstageCustomFieldCreateRequest,
+  ): Promise<BackstageCustomField> {
+    const body = JSON.stringify(request);
+
+    const options = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=UTF-8',
+        Accept: 'application/json, text/plain, */*',
+      },
+      body,
+    };
+
+    const url = `${await this.config.discoveryApi.getBaseUrl(
+      'pagerduty',
+    )}/custom-fields`;
+
+    const response = await this.request(url, options);
+    const result = await response.json();
+    return result.customField;
+  }
+
+  async getCustomFields(): Promise<BackstageCustomFieldsResponse> {
+    const url = `${await this.config.discoveryApi.getBaseUrl(
+      'pagerduty',
+    )}/custom-fields`;
+
+    return await this.findByUrl<BackstageCustomFieldsResponse>(url);
   }
 
   private async findByUrl<T>(url: string): Promise<T> {

--- a/plugins/backstage-plugin/src/api/client.ts
+++ b/plugins/backstage-plugin/src/api/client.ts
@@ -20,6 +20,7 @@ import {
   PagerDutyClientApiDependencies,
   PagerDutyClientApiConfig,
   RequestOptions,
+  Result,
 } from './types';
 import {
   PagerDutyChangeEventsResponse,
@@ -310,7 +311,7 @@ export class PagerDutyClient implements PagerDutyApi {
   async createCustomField(
     request: BackstageCustomFieldCreateRequest,
     account?: string,
-  ): Promise<BackstageCustomField> {
+  ): Promise<Result<BackstageCustomField>> {
     const body = JSON.stringify(request);
 
     const options = {
@@ -330,9 +331,43 @@ export class PagerDutyClient implements PagerDutyApi {
       url = url.concat(`?account=${account}`);
     }
 
-    const response = await this.request(url, options);
-    const result = await response.json();
-    return result.customField;
+    try {
+      const response = await this.request(url, options);
+      const result = await response.json();
+      return {
+        status: 'ok',
+        data: result.customField,
+        error: null,
+      };
+    } catch (error) {
+      if (error instanceof Error) {
+        // Check for specific error conditions and return appropriate error messages
+        if (error.message.includes('already been taken')) {
+          return {
+            status: 'error',
+            data: null,
+            error: 'A custom field with this name already exists',
+          };
+        }
+        if (error.message.toLowerCase().includes('product limit reached')) {
+          return {
+            status: 'error',
+            data: null,
+            error: 'Custom field limit reached. Maximum number of custom fields has been exceeded.',
+          };
+        }
+        return {
+          status: 'error',
+          data: null,
+          error: error.message,
+        };
+      }
+      return {
+        status: 'error',
+        data: null,
+        error: 'Failed to create custom field',
+      };
+    }
   }
 
   async getCustomFields(account?: string): Promise<BackstageCustomFieldsResponse> {

--- a/plugins/backstage-plugin/src/api/client.ts
+++ b/plugins/backstage-plugin/src/api/client.ts
@@ -373,27 +373,8 @@ export class PagerDutyClient implements PagerDutyApi {
 
     if (!response.ok) {
       const payload = await response.json();
-      let errorMessage = 'Unknown error';
-      
-      if (payload.error) {
-        if (typeof payload.error === 'string') {
-          errorMessage = payload.error;
-        } else if (payload.error.message) {
-          // Handle nested error object with message property
-          errorMessage = payload.error.message;
-          // If there are specific error details, append them
-          if (payload.error.errors && Array.isArray(payload.error.errors)) {
-            const details = payload.error.errors.join(', ');
-            errorMessage += `: ${details}`;
-          }
-        } else {
-          errorMessage = JSON.stringify(payload.error);
-        }
-      } else if (payload.errors && Array.isArray(payload.errors)) {
-        errorMessage = payload.errors.map((error: string) => error).join(' ');
-      }
-      
-      const message = `Request failed with ${response.status}, ${errorMessage}`;
+      const errors = payload.errors.map((error: string) => error).join(' ');
+      const message = `Request failed with ${response.status}, ${errors}`;
       throw new Error(message);
     }
     return response;

--- a/plugins/backstage-plugin/src/api/client.ts
+++ b/plugins/backstage-plugin/src/api/client.ts
@@ -309,6 +309,7 @@ export class PagerDutyClient implements PagerDutyApi {
 
   async createCustomField(
     request: BackstageCustomFieldCreateRequest,
+    account?: string,
   ): Promise<BackstageCustomField> {
     const body = JSON.stringify(request);
 
@@ -321,19 +322,27 @@ export class PagerDutyClient implements PagerDutyApi {
       body,
     };
 
-    const url = `${await this.config.discoveryApi.getBaseUrl(
+    let url = `${await this.config.discoveryApi.getBaseUrl(
       'pagerduty',
     )}/custom-fields`;
+
+    if (account) {
+      url = url.concat(`?account=${account}`);
+    }
 
     const response = await this.request(url, options);
     const result = await response.json();
     return result.customField;
   }
 
-  async getCustomFields(): Promise<BackstageCustomFieldsResponse> {
-    const url = `${await this.config.discoveryApi.getBaseUrl(
+  async getCustomFields(account?: string): Promise<BackstageCustomFieldsResponse> {
+    let url = `${await this.config.discoveryApi.getBaseUrl(
       'pagerduty',
     )}/custom-fields`;
+
+    if (account) {
+      url = url.concat(`?account=${account}`);
+    }
 
     return await this.findByUrl<BackstageCustomFieldsResponse>(url);
   }

--- a/plugins/backstage-plugin/src/api/client.ts
+++ b/plugins/backstage-plugin/src/api/client.ts
@@ -393,7 +393,7 @@ export class PagerDutyClient implements PagerDutyApi {
         errorMessage = payload.errors.map((error: string) => error).join(' ');
       }
       
-      const message = `Request failed with ${response.status}: ${errorMessage}`;
+      const message = `Request failed with ${response.status}, ${errorMessage}`;
       throw new Error(message);
     }
     return response;

--- a/plugins/backstage-plugin/src/api/types.ts
+++ b/plugins/backstage-plugin/src/api/types.ts
@@ -162,12 +162,13 @@ export interface PagerDutyApi {
    */
   createCustomField(
     request: BackstageCustomFieldCreateRequest,
+    account?: string,
   ): Promise<BackstageCustomField>;
 
   /**
    * Fetches all custom fields.
    */
-  getCustomFields(): Promise<BackstageCustomFieldsResponse>;
+  getCustomFields(account?: string): Promise<BackstageCustomFieldsResponse>;
 }
 
 /** @public */

--- a/plugins/backstage-plugin/src/api/types.ts
+++ b/plugins/backstage-plugin/src/api/types.ts
@@ -25,6 +25,9 @@ import {
   PagerDutyServiceMetrics,
   PagerDutyEntityMappingsResponse,
   PagerDutySetting,
+  BackstageCustomFieldCreateRequest,
+  BackstageCustomField,
+  BackstageCustomFieldsResponse,
 } from '@pagerduty/backstage-plugin-common';
 import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
@@ -153,6 +156,18 @@ export interface PagerDutyApi {
    * Triggers an incident to whoever is on-call.
    */
   triggerAlarm(request: PagerDutyTriggerAlarmRequest): Promise<Response>;
+
+  /**
+   * Creates a custom field in PagerDuty and stores the mapping.
+   */
+  createCustomField(
+    request: BackstageCustomFieldCreateRequest,
+  ): Promise<BackstageCustomField>;
+
+  /**
+   * Fetches all custom fields.
+   */
+  getCustomFields(): Promise<BackstageCustomFieldsResponse>;
 }
 
 /** @public */

--- a/plugins/backstage-plugin/src/api/types.ts
+++ b/plugins/backstage-plugin/src/api/types.ts
@@ -25,35 +25,13 @@ import {
   PagerDutyServiceMetrics,
   PagerDutyEntityMappingsResponse,
   PagerDutySetting,
+  BackstageCustomField,
+  BackstageCustomFieldCreateRequest,
+  BackstageCustomFieldsResponse,
 } from '@pagerduty/backstage-plugin-common';
 import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { PagerDutyEntity } from '../types';
-
-/** @public */
-export type BackstageCustomField = {
-  id: number;
-  pagerdutyCustomFieldId: string;
-  pagerdutyCustomFieldDisplayName: string;
-  pagerdutyCustomFieldEnabled: boolean;
-  backstageEntityMappingPath: string;
-  pagerdutySubdomain: string;
-  description?: string;
-  createdAt: Date;
-  updatedAt: Date;
-};
-
-/** @public */
-export type BackstageCustomFieldCreateRequest = {
-  name: string;
-  entityPath: string;
-  description?: string;
-};
-
-/** @public */
-export type BackstageCustomFieldsResponse = {
-  customFields: BackstageCustomField[];
-};
 
 /** @public */
 export type PagerDutyTriggerAlarmRequest = {

--- a/plugins/backstage-plugin/src/api/types.ts
+++ b/plugins/backstage-plugin/src/api/types.ts
@@ -163,7 +163,7 @@ export interface PagerDutyApi {
   createCustomField(
     request: BackstageCustomFieldCreateRequest,
     account?: string,
-  ): Promise<BackstageCustomField>;
+  ): Promise<Result<BackstageCustomField>>;
 
   /**
    * Fetches all custom fields.
@@ -187,3 +187,8 @@ export type RequestOptions = {
   headers: HeadersInit;
   body?: BodyInit;
 };
+
+/** @public */
+export type Result<T> =
+  | { status: 'ok'; data: T; error: null }
+  | { status: 'error'; data: null; error: string };

--- a/plugins/backstage-plugin/src/api/types.ts
+++ b/plugins/backstage-plugin/src/api/types.ts
@@ -25,13 +25,35 @@ import {
   PagerDutyServiceMetrics,
   PagerDutyEntityMappingsResponse,
   PagerDutySetting,
-  BackstageCustomFieldCreateRequest,
-  BackstageCustomField,
-  BackstageCustomFieldsResponse,
 } from '@pagerduty/backstage-plugin-common';
 import { DiscoveryApi, FetchApi } from '@backstage/core-plugin-api';
 import { Entity } from '@backstage/catalog-model';
 import { PagerDutyEntity } from '../types';
+
+/** @public */
+export type BackstageCustomField = {
+  id: number;
+  pagerdutyCustomFieldId: string;
+  pagerdutyCustomFieldDisplayName: string;
+  pagerdutyCustomFieldEnabled: boolean;
+  backstageEntityMappingPath: string;
+  pagerdutySubdomain: string;
+  description?: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+/** @public */
+export type BackstageCustomFieldCreateRequest = {
+  name: string;
+  entityPath: string;
+  description?: string;
+};
+
+/** @public */
+export type BackstageCustomFieldsResponse = {
+  customFields: BackstageCustomField[];
+};
 
 /** @public */
 export type PagerDutyTriggerAlarmRequest = {

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/AddCustomFieldModal.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/AddCustomFieldModal.tsx
@@ -1,0 +1,164 @@
+import { useState, ChangeEvent } from 'react';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  TextField,
+  Typography,
+} from '@material-ui/core';
+import { createStyles, makeStyles } from '@material-ui/core/styles';
+import { BackstageTheme } from '@backstage/theme';
+import CloseIcon from '@material-ui/icons/Close';
+import { Alert } from '@material-ui/lab';
+
+const useStyles = makeStyles<BackstageTheme>(theme => {
+  return createStyles({
+    dialogTitle: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingRight: theme.spacing(1),
+    },
+    dialogContent: {
+      minWidth: 500,
+      paddingTop: theme.spacing(2),
+    },
+    formField: {
+      marginBottom: theme.spacing(2),
+    },
+    dialogActions: {
+      padding: theme.spacing(2, 3),
+    },
+    addButton: {
+      backgroundColor: theme.palette.primary.main,
+      color: theme.palette.primary.contrastText,
+      '&:hover': {
+        backgroundColor: theme.palette.primary.dark,
+      },
+    },
+    error: {
+      marginBottom: theme.spacing(2),
+    },
+  });
+});
+
+interface FormData {
+  name: string;
+  entityPath: string;
+  description: string;
+}
+
+interface AddCustomFieldModalProps {
+  open: boolean;
+  saving: boolean;
+  error: string | null;
+  onClose: () => void;
+  onSave: (data: FormData) => Promise<void>;
+}
+
+/** @public */
+export const AddCustomFieldModal = ({
+  open,
+  saving,
+  error,
+  onClose,
+  onSave,
+}: AddCustomFieldModalProps) => {
+  const classes = useStyles();
+  const [formData, setFormData] = useState<FormData>({
+    name: '',
+    entityPath: '',
+    description: '',
+  });
+
+  const handleFormChange = (field: keyof FormData) => (
+    event: ChangeEvent<HTMLInputElement>
+  ) => {
+    setFormData(prev => ({ ...prev, [field]: event.target.value }));
+  };
+
+  const handleClose = () => {
+    setFormData({ name: '', entityPath: '', description: '' });
+    onClose();
+  };
+
+  const handleSave = async () => {
+    await onSave(formData);
+    setFormData({ name: '', entityPath: '', description: '' });
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="sm"
+      fullWidth
+    >
+      <DialogTitle disableTypography>
+        <Box className={classes.dialogTitle}>
+          <Typography variant="h6">Add New Custom Field</Typography>
+          <IconButton
+            aria-label="close"
+            onClick={handleClose}
+            size="small"
+          >
+            <CloseIcon />
+          </IconButton>
+        </Box>
+      </DialogTitle>
+      <DialogContent className={classes.dialogContent}>
+        {error && (
+          <Alert severity="error" className={classes.error}>
+            {error}
+          </Alert>
+        )}
+        <TextField
+          label="Name"
+          value={formData.name}
+          onChange={handleFormChange('name')}
+          fullWidth
+          variant="outlined"
+          className={classes.formField}
+          disabled={saving}
+        />
+        <TextField
+          label="Entity Path"
+          value={formData.entityPath}
+          onChange={handleFormChange('entityPath')}
+          fullWidth
+          variant="outlined"
+          className={classes.formField}
+          disabled={saving}
+        />
+        <TextField
+          label="Description"
+          value={formData.description}
+          onChange={handleFormChange('description')}
+          fullWidth
+          variant="outlined"
+          multiline
+          rows={3}
+          className={classes.formField}
+          disabled={saving}
+        />
+      </DialogContent>
+      <DialogActions className={classes.dialogActions}>
+        <Button onClick={handleClose} disabled={saving}>
+          Cancel
+        </Button>
+        <Button
+          variant="contained"
+          className={classes.addButton}
+          onClick={handleSave}
+          disabled={!formData.name || !formData.entityPath || saving}
+        >
+          {saving ? 'Adding...' : 'Add'}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/CustomFieldsTab.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/CustomFieldsTab.tsx
@@ -207,12 +207,16 @@ export const CustomFieldsTab = () => {
     } catch (err) {
       if (err instanceof Error) {
         // Handle specific error cases
-        if (err.message.includes('409')) {
+        if (err.message.includes('already been taken') || err.message.includes('409')) {
           setError('A custom field with this name already exists');
-        } else if (err.message.includes('413')) {
+        } else if (err.message.includes('413') || err.message.toLowerCase().includes('limit reached') || err.message.toLowerCase().includes('limit exceeded')) {
           setError(
             'Custom field limit reached. Maximum number of custom fields has been exceeded.',
           );
+        } else if (err.message.includes('400')) {
+          // Extract just the meaningful part from 400 errors
+          const match = err.message.match(/:\s*(.+)$/);
+          setError(match ? match[1] : err.message);
         } else {
           setError(err.message);
         }

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/CustomFieldsTab.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/CustomFieldsTab.tsx
@@ -207,9 +207,11 @@ export const CustomFieldsTab = () => {
     } catch (err) {
       if (err instanceof Error) {
         // Handle specific error cases
-        if (err.message.includes('already been taken') || err.message.includes('409')) {
+        if (err.message.includes('already been taken')) {
           setError('A custom field with this name already exists');
-        } else if (err.message.includes('413') || err.message.toLowerCase().includes('limit reached') || err.message.toLowerCase().includes('limit exceeded')) {
+        } else if (
+          err.message.toLowerCase().includes('product limit reached')
+        ) {
           setError(
             'Custom field limit reached. Maximum number of custom fields has been exceeded.',
           );

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/CustomFieldsTab.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/CustomFieldsTab.tsx
@@ -205,12 +205,10 @@ export const CustomFieldsTab = () => {
           setError(
             'Custom field limit reached. Maximum number of custom fields has been exceeded.',
           );
-        } else if (err.message.includes('400')) {
-          // Extract just the meaningful part from 400 errors
-          const match = err.message.match(/:\s*(.+)$/);
-          setError(match ? match[1] : err.message);
         } else {
-          setError(err.message);
+          // Strip "Request failed with XXX," prefix from error messages
+          const match = err.message.match(/^Request failed with \d+,\s*(.+)$/);
+          setError(match ? match[1] : err.message);
         }
       } else {
         setError('Failed to create custom field');

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/CustomFieldsTab.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/CustomFieldsTab.tsx
@@ -26,18 +26,8 @@ import CloseIcon from '@material-ui/icons/Close';
 import { useApi } from '@backstage/core-plugin-api';
 import { pagerDutyApiRef } from '../../api';
 import { Alert } from '@material-ui/lab';
+import { BackstageCustomField } from '@pagerduty/backstage-plugin-common';
 
-type CustomField = {
-  id: number;
-  pagerdutyCustomFieldId: string;
-  pagerdutyCustomFieldDisplayName: string;
-  pagerdutyCustomFieldEnabled: boolean;
-  backstageEntityMappingPath: string;
-  pagerdutySubdomain: string;
-  description?: string;
-  createdAt: Date;
-  updatedAt: Date;
-};
 
 const useStyles = makeStyles<BackstageTheme>(theme => {
   return createStyles({
@@ -143,7 +133,7 @@ const useStyles = makeStyles<BackstageTheme>(theme => {
 export const CustomFieldsTab = () => {
   const classes = useStyles();
   const pagerDutyApi = useApi(pagerDutyApiRef);
-  const [customFields, setCustomFields] = useState<CustomField[]>([]);
+  const [customFields, setCustomFields] = useState<BackstageCustomField[]>([]);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/CustomFieldsTab.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/CustomFieldsTab.tsx
@@ -1,8 +1,14 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Box,
   Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
   Divider,
+  IconButton,
   Link,
   Paper,
   Table,
@@ -11,15 +17,26 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  TextField,
   Typography,
 } from '@material-ui/core';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import { BackstageTheme } from '@backstage/theme';
+import CloseIcon from '@material-ui/icons/Close';
+import { useApi } from '@backstage/core-plugin-api';
+import { pagerDutyApiRef } from '../../api';
+import { Alert } from '@material-ui/lab';
 
 type CustomField = {
-  id: string;
-  customField: string;
-  entityPath: string;
+  id: number;
+  pagerdutyCustomFieldId: string;
+  pagerdutyCustomFieldDisplayName: string;
+  pagerdutyCustomFieldEnabled: boolean;
+  backstageEntityMappingPath: string;
+  pagerdutySubdomain: string;
+  description?: string;
+  createdAt: Date;
+  updatedAt: Date;
 };
 
 const useStyles = makeStyles<BackstageTheme>(theme => {
@@ -88,20 +105,123 @@ const useStyles = makeStyles<BackstageTheme>(theme => {
         backgroundColor: theme.palette.primary.dark,
       },
     },
+    dialogTitle: {
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingRight: theme.spacing(1),
+    },
+    dialogContent: {
+      minWidth: 500,
+      paddingTop: theme.spacing(2),
+    },
+    formField: {
+      marginBottom: theme.spacing(2),
+    },
+    dialogActions: {
+      padding: theme.spacing(2, 3),
+    },
+    addButton: {
+      backgroundColor: theme.palette.primary.main,
+      color: theme.palette.primary.contrastText,
+      '&:hover': {
+        backgroundColor: theme.palette.primary.dark,
+      },
+    },
+    error: {
+      marginBottom: theme.spacing(2),
+    },
+    loading: {
+      display: 'flex',
+      justifyContent: 'center',
+      padding: theme.spacing(4),
+    },
   });
 });
 
 /** @public */
 export const CustomFieldsTab = () => {
   const classes = useStyles();
+  const pagerDutyApi = useApi(pagerDutyApiRef);
   const [customFields, setCustomFields] = useState<CustomField[]>([]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [formData, setFormData] = useState({
+    name: '',
+    entityPath: '',
+    description: '',
+  });
+
+  // Fetch custom fields on mount
+  useEffect(() => {
+    const fetchCustomFields = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await pagerDutyApi.getCustomFields();
+        setCustomFields(response.customFields);
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : 'Failed to load custom fields',
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCustomFields();
+  }, [pagerDutyApi]);
 
   const handleAddCustomField = () => {
-    const id = window.crypto.randomUUID();
-    setCustomFields(prev => [
-      ...prev,
-      { id, customField: '', entityPath: '' },
-    ]);
+    setIsModalOpen(true);
+    setError(null);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+    setFormData({ name: '', entityPath: '', description: '' });
+    setError(null);
+  };
+
+  const handleFormChange = (field: string) => (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setFormData(prev => ({ ...prev, [field]: event.target.value }));
+  };
+
+  const handleSaveCustomField = async () => {
+    setSaving(true);
+    setError(null);
+    
+    try {
+      const newCustomField = await pagerDutyApi.createCustomField({
+        name: formData.name,
+        entityPath: formData.entityPath,
+        description: formData.description,
+      });
+
+      setCustomFields(prev => [...prev, newCustomField]);
+      handleCloseModal();
+    } catch (err) {
+      if (err instanceof Error) {
+        // Handle specific error cases
+        if (err.message.includes('409')) {
+          setError('A custom field with this name already exists');
+        } else if (err.message.includes('413')) {
+          setError(
+            'Custom field limit reached. Maximum number of custom fields has been exceeded.',
+          );
+        } else {
+          setError(err.message);
+        }
+      } else {
+        setError('Failed to create custom field');
+      }
+    } finally {
+      setSaving(false);
+    }
   };
 
   const handleStartDataSync = () => {
@@ -152,36 +272,42 @@ export const CustomFieldsTab = () => {
           </Box>
         </Box>
 
-        <TableContainer component={Paper} variant="outlined">
-          <Table size="small">
-            <TableHead className={classes.tableHeader}>
-              <TableRow>
-                <TableCell className={classes.tableHeaderCell}>
-                  Custom Field
-                </TableCell>
-                <TableCell className={classes.tableHeaderCell}>
-                  Entity Path
-                </TableCell>
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {customFields.length === 0 ? (
+        {loading ? (
+          <Box className={classes.loading}>
+            <CircularProgress />
+          </Box>
+        ) : (
+          <TableContainer component={Paper} variant="outlined">
+            <Table size="small">
+              <TableHead className={classes.tableHeader}>
                 <TableRow>
-                  <TableCell colSpan={2} className={classes.emptyState}>
-                    No custom fields have been added
+                  <TableCell className={classes.tableHeaderCell}>
+                    Custom Field
+                  </TableCell>
+                  <TableCell className={classes.tableHeaderCell}>
+                    Entity Path
                   </TableCell>
                 </TableRow>
-              ) : (
-                customFields.map(field => (
-                  <TableRow key={field.id}>
-                    <TableCell>{field.customField}</TableCell>
-                    <TableCell>{field.entityPath}</TableCell>
+              </TableHead>
+              <TableBody>
+                {customFields.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={2} className={classes.emptyState}>
+                      No custom fields have been added
+                    </TableCell>
                   </TableRow>
-                ))
-              )}
-            </TableBody>
-          </Table>
-        </TableContainer>
+                ) : (
+                  customFields.map(field => (
+                    <TableRow key={field.id}>
+                      <TableCell>{field.pagerdutyCustomFieldDisplayName}</TableCell>
+                      <TableCell>{field.backstageEntityMappingPath}</TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
       </Box>
 
       <Box className={classes.footer}>
@@ -189,6 +315,75 @@ export const CustomFieldsTab = () => {
           Save
         </Button>
       </Box>
+
+      <Dialog
+        open={isModalOpen}
+        onClose={handleCloseModal}
+        maxWidth="sm"
+        fullWidth
+      >
+        <DialogTitle disableTypography>
+          <Box className={classes.dialogTitle}>
+            <Typography variant="h6">Add New Custom Field</Typography>
+            <IconButton
+              aria-label="close"
+              onClick={handleCloseModal}
+              size="small"
+            >
+              <CloseIcon />
+            </IconButton>
+          </Box>
+        </DialogTitle>
+        <DialogContent className={classes.dialogContent}>
+          {error && (
+            <Alert severity="error" className={classes.error}>
+              {error}
+            </Alert>
+          )}
+          <TextField
+            label="Name"
+            value={formData.name}
+            onChange={handleFormChange('name')}
+            fullWidth
+            variant="outlined"
+            className={classes.formField}
+            disabled={saving}
+          />
+          <TextField
+            label="Entity Path"
+            value={formData.entityPath}
+            onChange={handleFormChange('entityPath')}
+            fullWidth
+            variant="outlined"
+            className={classes.formField}
+            disabled={saving}
+          />
+          <TextField
+            label="Description"
+            value={formData.description}
+            onChange={handleFormChange('description')}
+            fullWidth
+            variant="outlined"
+            multiline
+            rows={3}
+            className={classes.formField}
+            disabled={saving}
+          />
+        </DialogContent>
+        <DialogActions className={classes.dialogActions}>
+          <Button onClick={handleCloseModal} disabled={saving}>
+            Cancel
+          </Button>
+          <Button
+            variant="contained"
+            className={classes.addButton}
+            onClick={handleSaveCustomField}
+            disabled={!formData.name || !formData.entityPath || saving}
+          >
+            {saving ? 'Adding...' : 'Add'}
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Paper>
   );
 };

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/CustomFieldsTab.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/CustomFieldsTab.tsx
@@ -142,35 +142,20 @@ export const CustomFieldsTab = () => {
     setSaving(true);
     setError(null);
 
-    try {
-      const newCustomField = await pagerDutyApi.createCustomField({
-        name: formData.name,
-        entityPath: formData.entityPath,
-        description: formData.description,
-      });
+    const result = await pagerDutyApi.createCustomField({
+      name: formData.name,
+      entityPath: formData.entityPath,
+      description: formData.description,
+    });
 
-      setCustomFields(prev => [...prev, newCustomField]);
+    if (result.status === 'ok') {
+      setCustomFields(prev => [...prev, result.data]);
       setIsModalOpen(false);
-    } catch (err) {
-      if (err instanceof Error) {
-        // Handle specific error cases
-        if (err.message.includes('already been taken')) {
-          setError('A custom field with this name already exists');
-        } else if (
-          err.message.toLowerCase().includes('product limit reached')
-        ) {
-          setError(
-            'Custom field limit reached. Maximum number of custom fields has been exceeded.',
-          );
-        } else {
-          setError(err.message);
-        }
-      } else {
-        setError('Failed to create custom field');
-      }
-    } finally {
-      setSaving(false);
+    } else {
+      setError(result.error);
     }
+
+    setSaving(false);
   };
 
   const handleStartDataSync = () => {

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/CustomFieldsTab.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/CustomFieldsTab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, ChangeEvent } from 'react';
 import {
   Box,
   Button,
@@ -186,7 +186,7 @@ export const CustomFieldsTab = () => {
   };
 
   const handleFormChange = (field: string) => (
-    event: React.ChangeEvent<HTMLInputElement>
+    event: ChangeEvent<HTMLInputElement>
   ) => {
     setFormData(prev => ({ ...prev, [field]: event.target.value }));
   };

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/CustomFieldsTab.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/CustomFieldsTab.tsx
@@ -1,14 +1,9 @@
-import { useState, useEffect, ChangeEvent } from 'react';
+import { useState, useEffect } from 'react';
 import {
   Box,
   Button,
   CircularProgress,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
   Divider,
-  IconButton,
   Link,
   Paper,
   Table,
@@ -17,16 +12,14 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  TextField,
   Typography,
 } from '@material-ui/core';
 import { createStyles, makeStyles } from '@material-ui/core/styles';
 import { BackstageTheme } from '@backstage/theme';
-import CloseIcon from '@material-ui/icons/Close';
 import { useApi } from '@backstage/core-plugin-api';
 import { pagerDutyApiRef } from '../../api';
-import { Alert } from '@material-ui/lab';
 import { BackstageCustomField } from '@pagerduty/backstage-plugin-common';
+import { AddCustomFieldModal } from './AddCustomFieldModal';
 
 
 const useStyles = makeStyles<BackstageTheme>(theme => {
@@ -95,32 +88,6 @@ const useStyles = makeStyles<BackstageTheme>(theme => {
         backgroundColor: theme.palette.primary.dark,
       },
     },
-    dialogTitle: {
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      paddingRight: theme.spacing(1),
-    },
-    dialogContent: {
-      minWidth: 500,
-      paddingTop: theme.spacing(2),
-    },
-    formField: {
-      marginBottom: theme.spacing(2),
-    },
-    dialogActions: {
-      padding: theme.spacing(2, 3),
-    },
-    addButton: {
-      backgroundColor: theme.palette.primary.main,
-      color: theme.palette.primary.contrastText,
-      '&:hover': {
-        backgroundColor: theme.palette.primary.dark,
-      },
-    },
-    error: {
-      marginBottom: theme.spacing(2),
-    },
     loading: {
       display: 'flex',
       justifyContent: 'center',
@@ -138,15 +105,10 @@ export const CustomFieldsTab = () => {
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [formData, setFormData] = useState({
-    name: '',
-    entityPath: '',
-    description: '',
-  });
 
   // Fetch custom fields on mount
   useEffect(() => {
-    const fetchCustomFields = async () => {
+    (async () => {
       setLoading(true);
       setError(null);
       try {
@@ -159,9 +121,7 @@ export const CustomFieldsTab = () => {
       } finally {
         setLoading(false);
       }
-    };
-
-    fetchCustomFields();
+    })();
   }, [pagerDutyApi]);
 
   const handleAddCustomField = () => {
@@ -171,20 +131,17 @@ export const CustomFieldsTab = () => {
 
   const handleCloseModal = () => {
     setIsModalOpen(false);
-    setFormData({ name: '', entityPath: '', description: '' });
     setError(null);
   };
 
-  const handleFormChange = (field: string) => (
-    event: ChangeEvent<HTMLInputElement>
-  ) => {
-    setFormData(prev => ({ ...prev, [field]: event.target.value }));
-  };
-
-  const handleSaveCustomField = async () => {
+  const handleSaveCustomField = async (formData: {
+    name: string;
+    entityPath: string;
+    description: string;
+  }) => {
     setSaving(true);
     setError(null);
-    
+
     try {
       const newCustomField = await pagerDutyApi.createCustomField({
         name: formData.name,
@@ -193,7 +150,7 @@ export const CustomFieldsTab = () => {
       });
 
       setCustomFields(prev => [...prev, newCustomField]);
-      handleCloseModal();
+      setIsModalOpen(false);
     } catch (err) {
       if (err instanceof Error) {
         // Handle specific error cases
@@ -206,9 +163,7 @@ export const CustomFieldsTab = () => {
             'Custom field limit reached. Maximum number of custom fields has been exceeded.',
           );
         } else {
-          // Strip "Request failed with XXX," prefix from error messages
-          const match = err.message.match(/^Request failed with \d+,\s*(.+)$/);
-          setError(match ? match[1] : err.message);
+          setError(err.message);
         }
       } else {
         setError('Failed to create custom field');
@@ -310,74 +265,13 @@ export const CustomFieldsTab = () => {
         </Button>
       </Box>
 
-      <Dialog
+      <AddCustomFieldModal
         open={isModalOpen}
+        saving={saving}
+        error={error}
         onClose={handleCloseModal}
-        maxWidth="sm"
-        fullWidth
-      >
-        <DialogTitle disableTypography>
-          <Box className={classes.dialogTitle}>
-            <Typography variant="h6">Add New Custom Field</Typography>
-            <IconButton
-              aria-label="close"
-              onClick={handleCloseModal}
-              size="small"
-            >
-              <CloseIcon />
-            </IconButton>
-          </Box>
-        </DialogTitle>
-        <DialogContent className={classes.dialogContent}>
-          {error && (
-            <Alert severity="error" className={classes.error}>
-              {error}
-            </Alert>
-          )}
-          <TextField
-            label="Name"
-            value={formData.name}
-            onChange={handleFormChange('name')}
-            fullWidth
-            variant="outlined"
-            className={classes.formField}
-            disabled={saving}
-          />
-          <TextField
-            label="Entity Path"
-            value={formData.entityPath}
-            onChange={handleFormChange('entityPath')}
-            fullWidth
-            variant="outlined"
-            className={classes.formField}
-            disabled={saving}
-          />
-          <TextField
-            label="Description"
-            value={formData.description}
-            onChange={handleFormChange('description')}
-            fullWidth
-            variant="outlined"
-            multiline
-            rows={3}
-            className={classes.formField}
-            disabled={saving}
-          />
-        </DialogContent>
-        <DialogActions className={classes.dialogActions}>
-          <Button onClick={handleCloseModal} disabled={saving}>
-            Cancel
-          </Button>
-          <Button
-            variant="contained"
-            className={classes.addButton}
-            onClick={handleSaveCustomField}
-            disabled={!formData.name || !formData.entityPath || saving}
-          >
-            {saving ? 'Adding...' : 'Add'}
-          </Button>
-        </DialogActions>
-      </Dialog>
+        onSave={handleSaveCustomField}
+      />
     </Paper>
   );
 };


### PR DESCRIPTION
### Description

PagerDuty custom fields within the Backstage plugin. The primary changes add the ability to create and retrieve custom fields, persist them in the database, and expose REST endpoints for these operations.

https://pagerduty.atlassian.net/browse/DEVECO-532

**Backend API and Controller Enhancements:**

* Added new controller `CustomFieldsController` with methods to create and fetch custom fields, including validation, error handling, and mapping to PagerDuty and database records (`customFieldsController.ts`).
* Integrated the new controller into the main router, exposing `POST /custom-fields` and `GET /custom-fields` endpoints. [[1]](diffhunk://#diff-759137cead099b0e683e65350d75b5a88ccd921969788b4cc89d8c940d8e9575R47) [[2]](diffhunk://#diff-759137cead099b0e683e65350d75b5a88ccd921969788b4cc89d8c940d8e9575R302-R307) [[3]](diffhunk://#diff-759137cead099b0e683e65350d75b5a88ccd921969788b4cc89d8c940d8e9575R571-R580)

**PagerDuty API Integration:**

* Implemented `createCustomField` and `getCustomFields` functions in the PagerDuty API client, supporting creation and retrieval of custom fields via the PagerDuty API, with robust error handling. [[1]](diffhunk://#diff-d4469511857499b4e9c3d13ab826ab75400e9ac16feb772b928dcc3fdc64a4fcR27-R29) [[2]](diffhunk://#diff-d4469511857499b4e9c3d13ab826ab75400e9ac16feb772b928dcc3fdc64a4fcR1222-R1358)

**Database Layer Updates:**

* Extended the database schema and interface to support storing custom fields, including new types, insert, and retrieval methods in `PagerDutyBackendDatabase`. [[1]](diffhunk://#diff-453e258039acfccd7778ff7a8ad1638191ad7685472b7d6a58734437634ddfedR4) [[2]](diffhunk://#diff-453e258039acfccd7778ff7a8ad1638191ad7685472b7d6a58734437634ddfedR19-R30) [[3]](diffhunk://#diff-453e258039acfccd7778ff7a8ad1638191ad7685472b7d6a58734437634ddfedR44-R45) [[4]](diffhunk://#diff-453e258039acfccd7778ff7a8ad1638191ad7685472b7d6a58734437634ddfedR162-R224)

**Type Definitions and Mocking:**

* Added and exported new type definitions for custom fields, creation requests, and responses in the shared types package.
* Updated the mock PagerDuty API to support custom field operations for development and testing. [[1]](diffhunk://#diff-7fd618aa41382fb7ed26ef0e35ede8b42f006349c72c7e924da90d748a61cc22R25) [[2]](diffhunk://#diff-7fd618aa41382fb7ed26ef0e35ede8b42f006349c72c7e924da90d748a61cc22R255-R275)

**Testing:**

* Added comprehensive integration tests for the new custom field endpoints, covering success, validation errors, conflict, and unexpected errors.
* Updated client test imports to support new types and errors.

**Issue number:** (e.g. #123)

### Affected plugin

- [x] backstage-plugin
- [x] backstage-plugin-backend
- [ ] backstage-plugin-scaffolder-actions
- [ ] backstage-plugin-entity-processor

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [ ] Changes have been tested
- [ ] Changes have been tested in dark theme
- [ ] Changes are documented
- [ ] Changes generate _no new warnings_
- [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
