### PR TITLE
fix: Required accounts for single account setup

### DIFF
--- a/plugins/backstage-plugin/dev/mockPagerDutyApi.ts
+++ b/plugins/backstage-plugin/dev/mockPagerDutyApi.ts
@@ -431,7 +431,7 @@ export const mockPagerDutyApi: PagerDutyApi = {
     return users;
   },
 
-  async getAllTeams(_account: string) {
+  async getAllTeams(_account?: string) {
     return [
       {
         id: 'team1',

--- a/plugins/backstage-plugin/src/api/client.ts
+++ b/plugins/backstage-plugin/src/api/client.ts
@@ -185,9 +185,11 @@ export class PagerDutyClient implements PagerDutyApi {
     return await this.findByUrl<PagerDutyService[]>(url);
   }
 
-  async getAllTeams(account: string): Promise<PagerDutyTeam[]> {
+  async getAllTeams(account?: string): Promise<PagerDutyTeam[]> {
     const baseUrl = await this.config.discoveryApi.getBaseUrl('pagerduty');
-    const url = `${baseUrl}/teams?account=${encodeURIComponent(account)}`;
+    const url = account
+      ? `${baseUrl}/teams?account=${encodeURIComponent(account)}`
+      : `${baseUrl}/teams`;
 
     return await this.findByUrl<PagerDutyTeam[]>(url);
   }

--- a/plugins/backstage-plugin/src/api/types.ts
+++ b/plugins/backstage-plugin/src/api/types.ts
@@ -178,7 +178,7 @@ export interface PagerDutyApi {
    *
    * @param account - The account ID to filter teams by
    */
-  getAllTeams(account: string): Promise<PagerDutyTeam[]>;
+  getAllTeams(account?: string): Promise<PagerDutyTeam[]>;
 
   /**
    * Fetches a filtered list of PagerDuty services.

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsDialog.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/MappingsDialog.tsx
@@ -87,14 +87,16 @@ export default function MappingsDialog({
     }
   }, [isOpen]);
 
+  const accountParam = selectedAccount || undefined;
+
   const { data: teams, isLoading: isTeamsLoading } = useQuery({
-    queryKey: ['pagerduty', 'getAllTeams', selectedAccount],
-    queryFn: () => pagerDutyApi.getAllTeams(selectedAccount),
-    enabled: isOpen && !!selectedAccount,
+    queryKey: ['pagerduty', 'getAllTeams', accountParam],
+    queryFn: () => pagerDutyApi.getAllTeams(accountParam),
+    enabled: isOpen,
   });
 
   const { data: services, isLoading: isServicesLoading } = useQuery({
-    queryKey: ['pagerduty', 'getFilteredServices', selectedTeamId, debouncedSearchQuery, selectedAccount],
+    queryKey: ['pagerduty', 'getFilteredServices', selectedTeamId, debouncedSearchQuery, accountParam],
     queryFn: async () => {
       const teamIdsToSend = selectedTeamId ? [selectedTeamId] : undefined;
       const queryToSend = debouncedSearchQuery || undefined;
@@ -102,11 +104,11 @@ export default function MappingsDialog({
         teamIdsToSend,
         queryToSend,
         10,
-        selectedAccount,
+        accountParam,
       );
       return result;
     },
-    enabled: isOpen && !!selectedAccount,
+    enabled: isOpen,
   });
 
   const { mutateAsync: createMapping, isPending: isCreatingMapping } =


### PR DESCRIPTION
### Description

PD related data failed to load in single account setups because accounts were always expected to be sent to the API

**Issue number:** (e.g. #123)

### Affected plugin

- [X] backstage-plugin
- [ ] backstage-plugin-backend
- [ ] backstage-plugin-scaffolder-actions
- [ ] backstage-plugin-entity-processor

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [X] I have performed a self-review of this change
- [X] Changes have been tested
- [X] Changes have been tested in dark theme
- [ ] Changes are documented
- [X] Changes generate _no new warnings_
- [X] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
