### PR TITLE
feat: Push custom fields to PagerDuty during catalog processing

### DIFF
--- a/plugins/backstage-plugin-backend/src/apis/pagerduty.test.ts
+++ b/plugins/backstage-plugin-backend/src/apis/pagerduty.test.ts
@@ -19,6 +19,7 @@ import {
   getServiceStandards,
   insertAccountConfig,
   setFallbackAccountConfig,
+  setServiceCustomFieldValues,
   updateCustomField,
 } from './pagerduty';
 
@@ -1672,6 +1673,65 @@ describe('PagerDuty API', () => {
             method: 'PUT',
           }),
         );
+      },
+    );
+  });
+
+  describe('setServiceCustomFieldValues', () => {
+    it.each(testInputs)(
+      'PUTs values to /services/:id/custom_fields/values and returns the response',
+      async () => {
+        const responseBody = {
+          custom_fields: [{ id: 'PD123', value: 'team-a' }],
+        };
+        mocked(fetch).mockReturnValue(mockedResponse(200, responseBody));
+
+        const result = await setServiceCustomFieldValues({
+          serviceId: 'PSERV1',
+          request: {
+            custom_fields: [{ id: 'PD123', value: 'team-a' }],
+          },
+        });
+
+        expect(fetch).toHaveBeenCalledTimes(1);
+        expect(fetch).toHaveBeenCalledWith(
+          expect.stringContaining('/services/PSERV1/custom_fields/values'),
+          expect.objectContaining({
+            method: 'PUT',
+            body: JSON.stringify({
+              custom_fields: [{ id: 'PD123', value: 'team-a' }],
+            }),
+          }),
+        );
+        expect(result).toEqual(responseBody);
+      },
+    );
+
+    it.each(testInputs)(
+      'throws HttpError with status 404 when service not found',
+      async () => {
+        mocked(fetch).mockReturnValue(mockedResponse(404, {}));
+
+        await expect(
+          setServiceCustomFieldValues({
+            serviceId: 'MISSING',
+            request: { custom_fields: [{ id: 'PD123', value: 'x' }] },
+          }),
+        ).rejects.toMatchObject({ status: 404 });
+      },
+    );
+
+    it.each(testInputs)(
+      'throws HttpError with status 400 when request invalid',
+      async () => {
+        mocked(fetch).mockReturnValue(mockedResponse(400, { error: 'bad' }));
+
+        await expect(
+          setServiceCustomFieldValues({
+            serviceId: 'PSERV1',
+            request: { custom_fields: [{ id: 'PD123', value: 'x' }] },
+          }),
+        ).rejects.toMatchObject({ status: 400 });
       },
     );
   });

--- a/plugins/backstage-plugin-backend/src/apis/pagerduty.test.ts
+++ b/plugins/backstage-plugin-backend/src/apis/pagerduty.test.ts
@@ -19,7 +19,6 @@ import {
   getServiceStandards,
   insertAccountConfig,
   setFallbackAccountConfig,
-  setServiceCustomFieldValues,
   updateCustomField,
 } from './pagerduty';
 
@@ -1677,62 +1676,5 @@ describe('PagerDuty API', () => {
     );
   });
 
-  describe('setServiceCustomFieldValues', () => {
-    it.each(testInputs)(
-      'PUTs values to /services/:id/custom_fields/values and returns the response',
-      async () => {
-        const responseBody = {
-          custom_fields: [{ id: 'PD123', value: 'team-a' }],
-        };
-        mocked(fetch).mockReturnValue(mockedResponse(200, responseBody));
-
-        const result = await setServiceCustomFieldValues({
-          serviceId: 'PSERV1',
-          request: {
-            custom_fields: [{ id: 'PD123', value: 'team-a' }],
-          },
-        });
-
-        expect(fetch).toHaveBeenCalledTimes(1);
-        expect(fetch).toHaveBeenCalledWith(
-          expect.stringContaining('/services/PSERV1/custom_fields/values'),
-          expect.objectContaining({
-            method: 'PUT',
-            body: JSON.stringify({
-              custom_fields: [{ id: 'PD123', value: 'team-a' }],
-            }),
-          }),
-        );
-        expect(result).toEqual(responseBody);
-      },
-    );
-
-    it.each(testInputs)(
-      'throws HttpError with status 404 when service not found',
-      async () => {
-        mocked(fetch).mockReturnValue(mockedResponse(404, {}));
-
-        await expect(
-          setServiceCustomFieldValues({
-            serviceId: 'MISSING',
-            request: { custom_fields: [{ id: 'PD123', value: 'x' }] },
-          }),
-        ).rejects.toMatchObject({ status: 404 });
-      },
-    );
-
-    it.each(testInputs)(
-      'throws HttpError with status 400 when request invalid',
-      async () => {
-        mocked(fetch).mockReturnValue(mockedResponse(400, { error: 'bad' }));
-
-        await expect(
-          setServiceCustomFieldValues({
-            serviceId: 'PSERV1',
-            request: { custom_fields: [{ id: 'PD123', value: 'x' }] },
-          }),
-        ).rejects.toMatchObject({ status: 400 });
-      },
-    );
-  });
 });
+

--- a/plugins/backstage-plugin-backend/src/apis/pagerduty.ts
+++ b/plugins/backstage-plugin-backend/src/apis/pagerduty.ts
@@ -30,6 +30,8 @@ import {
   PagerDutyCustomFieldResponse,
   PagerDutyCustomFieldsResponse,
   PagerDutyCustomFieldUpdateRequest,
+  PagerDutyServiceCustomFieldValuesRequest,
+  PagerDutyServiceCustomFieldValuesResponse,
 } from '@pagerduty/backstage-plugin-common';
 
 import { DateTime } from 'luxon';
@@ -1784,3 +1786,81 @@ export async function getCustomFields({
   }
 }
 
+export type SetServiceCustomFieldValuesProps = {
+  serviceId: string;
+  request: PagerDutyServiceCustomFieldValuesRequest;
+  account?: string;
+};
+
+export async function setServiceCustomFieldValues({
+  serviceId,
+  request,
+  account,
+}: SetServiceCustomFieldValuesProps): Promise<PagerDutyServiceCustomFieldValuesResponse> {
+  const apiBaseUrl = getApiBaseUrl(account);
+  const baseUrl = `${apiBaseUrl}/services/${serviceId}/custom_fields/values`;
+  const token = await getAuthToken(account);
+
+  const options: RequestInit = {
+    method: 'PUT',
+    body: JSON.stringify(request),
+    headers: {
+      Authorization: token,
+      Accept: 'application/vnd.pagerduty+json;version=2',
+      'Content-Type': 'application/json',
+    },
+  };
+
+  let response: Response;
+  try {
+    response = await fetchWithRetries(baseUrl, options);
+  } catch (error) {
+    throw new Error(`Failed to set service custom field values: ${error}`);
+  }
+
+  if (response.status >= 500) {
+    throw new HttpError(
+      `Failed to set service custom field values. PagerDuty API returned a server error.`,
+      response.status,
+    );
+  }
+
+  switch (response.status) {
+    case 400: {
+      const errorData = await response.json().catch(() => ({}));
+      throw new HttpError(
+        `Failed to set service custom field values. Invalid arguments: ${JSON.stringify(errorData)}`,
+        400,
+      );
+    }
+    case 401:
+      throw new HttpError(
+        `Failed to set service custom field values. Invalid credentials provided.`,
+        401,
+      );
+    case 403:
+      throw new HttpError(
+        `Failed to set service custom field values. Not authorized to perform this action.`,
+        403,
+      );
+    case 404:
+      throw new HttpError(
+        `Failed to set service custom field values. Service or custom field not found.`,
+        404,
+      );
+    case 429:
+      throw new HttpError(`Rate limit exceeded.`, 429);
+    default: // 200
+      break;
+  }
+
+  try {
+    const result =
+      (await response.json()) as PagerDutyServiceCustomFieldValuesResponse;
+    return result;
+  } catch (error) {
+    throw new Error(
+      `Failed to parse set service custom field values response: ${error}`,
+    );
+  }
+}

--- a/plugins/backstage-plugin-backend/src/db/PagerDutyBackendDatabase.ts
+++ b/plugins/backstage-plugin-backend/src/db/PagerDutyBackendDatabase.ts
@@ -45,7 +45,10 @@ export interface PagerDutyBackendStore {
   findSetting(settingId: string): Promise<PagerDutySetting | undefined>;
   getAllSettings(): Promise<PagerDutySetting[]>;
   insertCustomField(customField: Omit<BackstageCustomField, 'id' | 'createdAt' | 'updatedAt'>): Promise<BackstageCustomField>;
-  getAllCustomFields(subdomain: string): Promise<BackstageCustomField[]>;
+  getAllCustomFields(
+    subdomain: string,
+    options?: { enabled?: boolean },
+  ): Promise<BackstageCustomField[]>;
   findCustomFieldById(id: number): Promise<BackstageCustomField | undefined>;
   updateCustomField(
     id: number,
@@ -230,7 +233,7 @@ export class PagerDutyBackendDatabase implements PagerDutyBackendStore {
       id: result.id,
       pagerdutyCustomFieldId: result.pagerdutyCustomFieldId,
       pagerdutyCustomFieldDisplayName: result.pagerdutyCustomFieldDisplayName,
-      pagerdutyCustomFieldEnabled: result.pagerdutyCustomFieldEnabled,
+      pagerdutyCustomFieldEnabled: Boolean(result.pagerdutyCustomFieldEnabled),
       backstageEntityMappingPath: result.backstageEntityMappingPath,
       pagerdutySubdomain: result.pagerdutySubdomain,
       description: result.description,
@@ -244,7 +247,12 @@ export class PagerDutyBackendDatabase implements PagerDutyBackendStore {
       .where('id', id)
       .first();
 
-    return result;
+    if (!result) return undefined;
+
+    return {
+      ...result,
+      pagerdutyCustomFieldEnabled: Boolean(result.pagerdutyCustomFieldEnabled),
+    };
   }
 
   async updateCustomField(
@@ -276,13 +284,24 @@ export class PagerDutyBackendDatabase implements PagerDutyBackendStore {
       throw new Error(`Failed to retrieve custom field after update for id: ${id}`);
     }
 
-    return result;
+    return {
+      ...result,
+      pagerdutyCustomFieldEnabled: Boolean(result.pagerdutyCustomFieldEnabled),
+    };
   }
 
-  async getAllCustomFields(subdomain: string): Promise<BackstageCustomField[]> {
-    const rawFields = await this.db<RawDbCustomFieldRow>(
-      'pagerduty_custom_fields',
-    ).where('pagerdutySubdomain', subdomain);
+  async getAllCustomFields(
+    subdomain: string,
+    options?: { enabled?: boolean },
+  ): Promise<BackstageCustomField[]> {
+    const query = this.db<RawDbCustomFieldRow>('pagerduty_custom_fields').where(
+      'pagerdutySubdomain',
+      subdomain,
+    );
+    if (options?.enabled !== undefined) {
+      query.where('pagerdutyCustomFieldEnabled', options.enabled);
+    }
+    const rawFields = await query;
 
     if (!rawFields) {
       return [];
@@ -292,7 +311,7 @@ export class PagerDutyBackendDatabase implements PagerDutyBackendStore {
       id: field.id,
       pagerdutyCustomFieldId: field.pagerdutyCustomFieldId,
       pagerdutyCustomFieldDisplayName: field.pagerdutyCustomFieldDisplayName,
-      pagerdutyCustomFieldEnabled: field.pagerdutyCustomFieldEnabled,
+      pagerdutyCustomFieldEnabled: Boolean(field.pagerdutyCustomFieldEnabled),
       backstageEntityMappingPath: field.backstageEntityMappingPath,
       pagerdutySubdomain: field.pagerdutySubdomain,
       description: field.description,

--- a/plugins/backstage-plugin-backend/src/db/PagerDutyBackendDatabase.ts
+++ b/plugins/backstage-plugin-backend/src/db/PagerDutyBackendDatabase.ts
@@ -201,6 +201,13 @@ export class PagerDutyBackendDatabase implements PagerDutyBackendStore {
     return rawEntities;
   }
 
+  private toBackstageCustomField(row: RawDbCustomFieldRow): BackstageCustomField {
+    return {
+      ...row,
+      pagerdutyCustomFieldEnabled: Boolean(row.pagerdutyCustomFieldEnabled),
+    };
+  }
+
   async insertCustomField(
     customField: Omit<BackstageCustomField, 'id' | 'createdAt' | 'updatedAt'>,
   ): Promise<BackstageCustomField> {
@@ -229,17 +236,7 @@ export class PagerDutyBackendDatabase implements PagerDutyBackendStore {
       );
     }
 
-    return {
-      id: result.id,
-      pagerdutyCustomFieldId: result.pagerdutyCustomFieldId,
-      pagerdutyCustomFieldDisplayName: result.pagerdutyCustomFieldDisplayName,
-      pagerdutyCustomFieldEnabled: Boolean(result.pagerdutyCustomFieldEnabled),
-      backstageEntityMappingPath: result.backstageEntityMappingPath,
-      pagerdutySubdomain: result.pagerdutySubdomain,
-      description: result.description,
-      createdAt: result.createdAt,
-      updatedAt: result.updatedAt,
-    };
+    return this.toBackstageCustomField(result);
   }
 
   async findCustomFieldById(id: number): Promise<BackstageCustomField | undefined> {
@@ -249,10 +246,7 @@ export class PagerDutyBackendDatabase implements PagerDutyBackendStore {
 
     if (!result) return undefined;
 
-    return {
-      ...result,
-      pagerdutyCustomFieldEnabled: Boolean(result.pagerdutyCustomFieldEnabled),
-    };
+    return this.toBackstageCustomField(result);
   }
 
   async updateCustomField(
@@ -284,21 +278,18 @@ export class PagerDutyBackendDatabase implements PagerDutyBackendStore {
       throw new Error(`Failed to retrieve custom field after update for id: ${id}`);
     }
 
-    return {
-      ...result,
-      pagerdutyCustomFieldEnabled: Boolean(result.pagerdutyCustomFieldEnabled),
-    };
+    return this.toBackstageCustomField(result);
   }
 
   async getAllCustomFields(
     subdomain: string,
-    options?: { enabled?: boolean },
+    options: { enabled?: boolean } = {},
   ): Promise<BackstageCustomField[]> {
     const query = this.db<RawDbCustomFieldRow>('pagerduty_custom_fields').where(
       'pagerdutySubdomain',
       subdomain,
     );
-    if (options?.enabled !== undefined) {
+    if (options.enabled !== undefined) {
       query.where('pagerdutyCustomFieldEnabled', options.enabled);
     }
     const rawFields = await query;
@@ -307,17 +298,7 @@ export class PagerDutyBackendDatabase implements PagerDutyBackendStore {
       return [];
     }
 
-    return rawFields.map(field => ({
-      id: field.id,
-      pagerdutyCustomFieldId: field.pagerdutyCustomFieldId,
-      pagerdutyCustomFieldDisplayName: field.pagerdutyCustomFieldDisplayName,
-      pagerdutyCustomFieldEnabled: Boolean(field.pagerdutyCustomFieldEnabled),
-      backstageEntityMappingPath: field.backstageEntityMappingPath,
-      pagerdutySubdomain: field.pagerdutySubdomain,
-      description: field.description,
-      createdAt: field.createdAt,
-      updatedAt: field.updatedAt,
-    }));
+    return rawFields.map(field => this.toBackstageCustomField(field));
   }
 
   async deleteCustomField(id: number): Promise<void> {

--- a/plugins/backstage-plugin-backend/src/service/customFieldsController.ts
+++ b/plugins/backstage-plugin-backend/src/service/customFieldsController.ts
@@ -1,7 +1,11 @@
 import { LoggerService } from '@backstage/backend-plugin-api';
 import { Request, Response } from 'express';
 import { PagerDutyBackendStore } from '../db/PagerDutyBackendDatabase';
-import { createCustomField, updateCustomField } from '../apis/pagerduty';
+import {
+  createCustomField,
+  setServiceCustomFieldValues,
+  updateCustomField,
+} from '../apis/pagerduty';
 import {
   BackstageCustomFieldCreateRequest,
   BackstageCustomFieldUpdateRequest,
@@ -9,6 +13,7 @@ import {
   HttpError,
   PagerDutyCustomFieldCreateRequest,
   PagerDutyCustomFieldUpdateRequest,
+  PagerDutyServiceCustomFieldValue,
 } from '@pagerduty/backstage-plugin-common';
 
 export interface CustomFieldsControllerOptions {
@@ -115,11 +120,56 @@ export class CustomFieldsController {
   async getCustomFields(request: Request, response: Response): Promise<void> {
     try {
       const subdomain = this.getSubdomainFromRequest(request);
-      const customFields = await this.store.getAllCustomFields(subdomain);
+      const enabled = parseEnabledQuery(request.query.enabled);
+      const customFields = await this.store.getAllCustomFields(subdomain, {
+        enabled,
+      });
       const responseData: BackstageCustomFieldsResponse = { customFields };
       response.status(200).json(responseData);
     } catch (error) {
       this.handleUnexpectedError(error, 'fetching custom fields', response);
+    }
+  }
+
+  async syncCustomFieldValues(
+    request: Request,
+    response: Response,
+  ): Promise<void> {
+    try {
+      const { serviceId, values } = request.body as {
+        serviceId?: string;
+        values?: PagerDutyServiceCustomFieldValue[];
+      };
+      const subdomain = this.getSubdomainFromRequest(request);
+
+      if (!serviceId) {
+        throw new HttpError('Missing required field: serviceId', 400);
+      }
+      if (!Array.isArray(values) || values.length === 0) {
+        response.status(204).end();
+        return;
+      }
+
+      try {
+        await setServiceCustomFieldValues({
+          serviceId,
+          request: { custom_fields: values },
+          account: subdomain,
+        });
+        this.logger.info(
+          `Synced ${values.length} custom field value(s) to PagerDuty service ${serviceId}`,
+        );
+        response.status(204).end();
+      } catch (error) {
+        if (error instanceof HttpError) this.handlePagerDutyError(error);
+        throw error;
+      }
+    } catch (error) {
+      this.handleUnexpectedError(
+        error,
+        'syncing custom field values',
+        response,
+      );
     }
   }
 
@@ -364,4 +414,10 @@ export class CustomFieldsController {
       });
     }
   }
+}
+
+function parseEnabledQuery(value: unknown): boolean | undefined {
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  return undefined;
 }

--- a/plugins/backstage-plugin-backend/src/service/customFieldsController.ts
+++ b/plugins/backstage-plugin-backend/src/service/customFieldsController.ts
@@ -151,7 +151,7 @@ export class CustomFieldsController {
       }
 
       try {
-        await setServiceCustomFieldValues({
+        const result = await setServiceCustomFieldValues({
           serviceId,
           request: { custom_fields: values },
           account: subdomain,
@@ -159,7 +159,7 @@ export class CustomFieldsController {
         this.logger.info(
           `Synced ${values.length} custom field value(s) to PagerDuty service ${serviceId}`,
         );
-        response.status(204).end();
+        response.status(200).json(result);
       } catch (error) {
         if (error instanceof HttpError) this.handlePagerDutyError(error);
         throw error;

--- a/plugins/backstage-plugin-backend/src/service/router.test.ts
+++ b/plugins/backstage-plugin-backend/src/service/router.test.ts
@@ -3985,6 +3985,68 @@ describe('createRouter', () => {
         expect(Array.isArray(response.body.customFields)).toBe(true);
       },
     );
+
+    it('filters out disabled fields when enabled=true', async () => {
+      const filtered = await request(app).get('/custom-fields?enabled=true');
+      expect(filtered.status).toEqual(200);
+      filtered.body.customFields.forEach((f: { pagerdutyCustomFieldEnabled: boolean }) => {
+        expect(f.pagerdutyCustomFieldEnabled).toBe(true);
+      });
+    });
+  });
+
+  describe('POST /custom-fields/sync', () => {
+    it('returns 204 with no values', async () => {
+      const response = await request(app)
+        .post('/custom-fields/sync')
+        .send({ serviceId: 'PSERV1', values: [] });
+
+      expect(response.status).toEqual(204);
+      // PagerDuty should NOT be called when there are no values
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns 400 when serviceId is missing', async () => {
+      const response = await request(app)
+        .post('/custom-fields/sync')
+        .send({ values: [{ id: 'PD123', value: 'x' }] });
+
+      expect(response.status).toEqual(400);
+    });
+
+    it('forwards values to PagerDuty and returns 204', async () => {
+      mocked(fetch).mockReturnValue(
+        mockedResponse(200, {
+          custom_fields: [{ id: 'PD123', value: 'team-a' }],
+        }),
+      );
+
+      const response = await request(app)
+        .post('/custom-fields/sync')
+        .send({
+          serviceId: 'PSERV1',
+          values: [{ id: 'PD123', value: 'team-a' }],
+        });
+
+      expect(response.status).toEqual(204);
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/services/PSERV1/custom_fields/values'),
+        expect.objectContaining({ method: 'PUT' }),
+      );
+    });
+
+    it('returns 404 when PagerDuty reports the service is missing', async () => {
+      mocked(fetch).mockReturnValue(mockedResponse(404, {}));
+
+      const response = await request(app)
+        .post('/custom-fields/sync')
+        .send({
+          serviceId: 'MISSING',
+          values: [{ id: 'PD123', value: 'x' }],
+        });
+
+      expect(response.status).toEqual(404);
+    });
   });
   });
 });

--- a/plugins/backstage-plugin-backend/src/service/router.test.ts
+++ b/plugins/backstage-plugin-backend/src/service/router.test.ts
@@ -3989,6 +3989,7 @@ describe('createRouter', () => {
     it('filters out disabled fields when enabled=true', async () => {
       const filtered = await request(app).get('/custom-fields?enabled=true');
       expect(filtered.status).toEqual(200);
+      expect(filtered.body.customFields.length).toBeGreaterThan(0);
       filtered.body.customFields.forEach((f: { pagerdutyCustomFieldEnabled: boolean }) => {
         expect(f.pagerdutyCustomFieldEnabled).toBe(true);
       });
@@ -3996,6 +3997,12 @@ describe('createRouter', () => {
   });
 
   describe('POST /custom-fields/sync', () => {
+    const syncResponseBody = { custom_fields: [{ id: 'PD123', value: 'team-a' }] };
+
+    beforeEach(() => {
+      mocked(fetch).mockReturnValue(mockedResponse(200, syncResponseBody));
+    });
+
     it('returns 204 with no values', async () => {
       const response = await request(app)
         .post('/custom-fields/sync')
@@ -4014,13 +4021,7 @@ describe('createRouter', () => {
       expect(response.status).toEqual(400);
     });
 
-    it('forwards values to PagerDuty and returns 204', async () => {
-      mocked(fetch).mockReturnValue(
-        mockedResponse(200, {
-          custom_fields: [{ id: 'PD123', value: 'team-a' }],
-        }),
-      );
-
+    it('forwards values to PagerDuty and returns 200 with body', async () => {
       const response = await request(app)
         .post('/custom-fields/sync')
         .send({
@@ -4028,7 +4029,8 @@ describe('createRouter', () => {
           values: [{ id: 'PD123', value: 'team-a' }],
         });
 
-      expect(response.status).toEqual(204);
+      expect(response.status).toEqual(200);
+      expect(response.body).toEqual(syncResponseBody);
       expect(fetch).toHaveBeenCalledWith(
         expect.stringContaining('/services/PSERV1/custom_fields/values'),
         expect.objectContaining({ method: 'PUT' }),

--- a/plugins/backstage-plugin-backend/src/service/router.ts
+++ b/plugins/backstage-plugin-backend/src/service/router.ts
@@ -545,6 +545,11 @@ export async function createRouter(
     await customFieldsController.updateCustomField(request, response);
   });
 
+  // POST /custom-fields/sync
+  router.post('/custom-fields/sync', async (request, response) => {
+    await customFieldsController.syncCustomFieldValues(request, response);
+  });
+
   // POST /mapping/entity
   router.post('/mapping/entity', async (request, response) => {
     try {

--- a/plugins/backstage-plugin-common/src/types.ts
+++ b/plugins/backstage-plugin-common/src/types.ts
@@ -488,3 +488,19 @@ export type PagerDutyCustomFieldUpdateRequest = {
 export type BackstageCustomFieldsResponse = {
   customFields: BackstageCustomField[];
 };
+
+/** @public */
+export type PagerDutyServiceCustomFieldValue = {
+  id: string;
+  value: string | null;
+};
+
+/** @public */
+export type PagerDutyServiceCustomFieldValuesRequest = {
+  custom_fields: PagerDutyServiceCustomFieldValue[];
+};
+
+/** @public */
+export type PagerDutyServiceCustomFieldValuesResponse = {
+  custom_fields: PagerDutyServiceCustomFieldValue[];
+};

--- a/plugins/backstage-plugin-common/src/types.ts
+++ b/plugins/backstage-plugin-common/src/types.ts
@@ -500,6 +500,8 @@ export type PagerDutyServiceCustomFieldValuesRequest = {
   custom_fields: PagerDutyServiceCustomFieldValue[];
 };
 
+// The PagerDuty API echoes back the same shape it receives, so these two types
+// are structurally identical but kept separate to distinguish call-site intent.
 /** @public */
 export type PagerDutyServiceCustomFieldValuesResponse = {
   custom_fields: PagerDutyServiceCustomFieldValue[];

--- a/plugins/backstage-plugin-entity-processor/src/apis/client.ts
+++ b/plugins/backstage-plugin-entity-processor/src/apis/client.ts
@@ -3,11 +3,14 @@ import type { RequestInit, Response } from 'node-fetch';
 import type { EntityMapping } from '../types';
 import { AuthService, DiscoveryService, LoggerService } from '@backstage/backend-plugin-api';
 import {
+  BackstageCustomField,
+  BackstageCustomFieldsResponse,
   PagerDutyEntityMapping,
   PagerDutyEntityMappingResponse,
   PagerDutyServiceResponse,
   PagerDutyServiceDependency,
   PagerDutyServiceDependencyResponse,
+  PagerDutyServiceCustomFieldValue,
   PagerDutySetting,
   PagerDutyEntityMappingsResponse,
 } from '@pagerduty/backstage-plugin-common';
@@ -622,6 +625,102 @@ export class PagerDutyClient {
     } catch (error) {
       this.logger.error(`Error getting value for setting: ${error}`);
       throw new Error(`Error getting value for setting: ${error}`);
+    }
+  }
+
+  async getEnabledCustomFields(account?: string): Promise<BackstageCustomField[]> {
+    let response: Response;
+
+    if (this.baseUrl === '') {
+      this.baseUrl = await this.discovery.getBaseUrl('pagerduty');
+    }
+
+    const options: RequestInit = {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json; charset=UTF-8',
+        Accept: 'application/json, text/plain, */*',
+        Authorization: await this.generatePluginToPluginToken(),
+      },
+    };
+
+    const params = new URLSearchParams({ enabled: 'true' });
+    if (account) params.set('account', account);
+
+    const url = `${await this.discovery.getBaseUrl(
+      'pagerduty',
+    )}/custom-fields?${params.toString()}`;
+
+    try {
+      response = await fetchWithRetries(url, options);
+
+      if (response.status >= 500) {
+        throw new Error(
+          `Failed to get enabled custom fields. API returned a server error.`,
+        );
+      }
+
+      switch (response.status) {
+        case 400:
+          throw new Error(await response.text());
+        case 404:
+          return [];
+        default: {
+          const body: BackstageCustomFieldsResponse = await response.json();
+          return body.customFields ?? [];
+        }
+      }
+    } catch (error) {
+      this.logger.error(`Failed to retrieve enabled custom fields: ${error}`);
+      return [];
+    }
+  }
+
+  async pushCustomFieldValues(
+    serviceId: string,
+    values: PagerDutyServiceCustomFieldValue[],
+    account?: string,
+  ): Promise<void> {
+    if (values.length === 0) return;
+
+    if (this.baseUrl === '') {
+      this.baseUrl = await this.discovery.getBaseUrl('pagerduty');
+    }
+
+    const params = new URLSearchParams();
+    if (account) params.set('account', account);
+    const query = params.toString() ? `?${params.toString()}` : '';
+
+    const options: RequestInit = {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json; charset=UTF-8',
+        Accept: 'application/json, text/plain, */*',
+        Authorization: await this.generatePluginToPluginToken(),
+      },
+      body: JSON.stringify({ serviceId, values }),
+    };
+
+    const url = `${await this.discovery.getBaseUrl(
+      'pagerduty',
+    )}/custom-fields/sync${query}`;
+
+    try {
+      const response = await fetchWithRetries(url, options);
+
+      if (response.status >= 500) {
+        throw new Error(
+          `Failed to push custom field values for service ${serviceId}. API returned a server error.`,
+        );
+      }
+
+      if (!response.ok && response.status !== 204) {
+        throw new Error(await response.text());
+      }
+    } catch (error) {
+      this.logger.error(
+        `Failed to push custom field values for service ${serviceId}: ${error}`,
+      );
     }
   }
 

--- a/plugins/backstage-plugin-entity-processor/src/apis/client.ts
+++ b/plugins/backstage-plugin-entity-processor/src/apis/client.ts
@@ -664,7 +664,7 @@ export class PagerDutyClient {
         case 400:
           throw new Error(await response.text());
         case 404:
-          return [];
+          throw new Error(`Custom fields endpoint not found. Ensure the PagerDuty backend plugin is running.`);
         default: {
           const body: BackstageCustomFieldsResponse = await response.json();
           return body.customFields ?? [];
@@ -689,7 +689,7 @@ export class PagerDutyClient {
 
     const params = new URLSearchParams();
     if (account) params.set('account', account);
-    const query = params.toString() ? `?${params.toString()}` : '';
+    const query = params.toString() ? `?${params}` : '';
 
     const options: RequestInit = {
       method: 'POST',

--- a/plugins/backstage-plugin-entity-processor/src/module.ts
+++ b/plugins/backstage-plugin-entity-processor/src/module.ts
@@ -3,7 +3,7 @@ import {
   createBackendModule,
 } from '@backstage/backend-plugin-api';
 import { catalogProcessingExtensionPoint } from '@backstage/plugin-catalog-node/alpha';
-import { PagerDutyEntityProcessor } from './processor';
+import { PagerDutyEntityProcessor, PagerDutyCustomFieldsProcessor } from './processor';
 
 /** @public */
 export const pagerDutyEntityProcessor = createBackendModule({
@@ -20,6 +20,9 @@ export const pagerDutyEntityProcessor = createBackendModule({
       async init({ auth, logger, discovery, catalog }) {
         catalog.addProcessor(
           new PagerDutyEntityProcessor({ auth, logger, discovery }),
+        );
+        catalog.addProcessor(
+          new PagerDutyCustomFieldsProcessor({ auth, logger, discovery }),
         );
       },
     });

--- a/plugins/backstage-plugin-entity-processor/src/processor/PagerDutyCustomFieldsProcessor.ts
+++ b/plugins/backstage-plugin-entity-processor/src/processor/PagerDutyCustomFieldsProcessor.ts
@@ -1,0 +1,70 @@
+import { AuthService, DiscoveryService, LoggerService } from '@backstage/backend-plugin-api';
+import { Entity } from '@backstage/catalog-model';
+import { CatalogProcessor, CatalogProcessorEmit } from '@backstage/plugin-catalog-node';
+import { LocationSpec } from '@backstage/plugin-catalog-common';
+import { PagerDutyClient } from '../apis/client';
+import { extractValueAtPath } from './extractEntityValue';
+import { PagerDutyServiceCustomFieldValue } from '@pagerduty/backstage-plugin-common';
+
+export interface PagerDutyCustomFieldsProcessorOptions {
+  logger: LoggerService;
+  discovery: DiscoveryService;
+  auth: AuthService;
+}
+
+export class PagerDutyCustomFieldsProcessor implements CatalogProcessor {
+  private readonly logger: LoggerService;
+  private readonly client: PagerDutyClient;
+
+  constructor({ auth, logger, discovery }: PagerDutyCustomFieldsProcessorOptions) {
+    this.logger = logger;
+    this.client = new PagerDutyClient({ auth, discovery, logger });
+  }
+
+  getProcessorName(): string {
+    return 'PagerDutyCustomFieldsProcessor';
+  }
+
+  async postProcessEntity(
+    entity: Entity,
+    _location: LocationSpec,
+    _emit: CatalogProcessorEmit,
+  ): Promise<Entity> {
+    if (entity.kind !== 'Component') return entity;
+
+    const serviceId = entity.metadata.annotations?.['pagerduty.com/service-id'];
+    if (!serviceId) return entity;
+
+    const account = entity.metadata.annotations?.['pagerduty.com/account'];
+
+    try {
+      const fields = await this.client.getEnabledCustomFields(account);
+      if (fields.length === 0) return entity;
+
+      const values: PagerDutyServiceCustomFieldValue[] = [];
+      for (const field of fields) {
+        const result = extractValueAtPath(entity, field.backstageEntityMappingPath);
+        if (!result.ok) {
+          this.logger.warn(
+            `Skipping custom field "${field.pagerdutyCustomFieldDisplayName}" for entity ${entity.metadata.name} (service ${serviceId}): ${result.reason}`,
+          );
+          continue;
+        }
+        values.push({ id: field.pagerdutyCustomFieldId, value: result.value });
+      }
+
+      if (values.length > 0) {
+        await this.client.pushCustomFieldValues(serviceId, values, account);
+        this.logger.debug(
+          `Pushed ${values.length} custom field value(s) for service ${serviceId}`,
+        );
+      }
+    } catch (error) {
+      this.logger.error(
+        `Failed to push custom field values for entity ${entity.metadata.name} (service ${serviceId}): ${error}`,
+      );
+    }
+
+    return entity;
+  }
+}

--- a/plugins/backstage-plugin-entity-processor/src/processor/PagerDutyEntityProcessor.ts
+++ b/plugins/backstage-plugin-entity-processor/src/processor/PagerDutyEntityProcessor.ts
@@ -11,6 +11,8 @@ import {
 } from '@backstage/plugin-catalog-node';
 import { LocationSpec } from '@backstage/plugin-catalog-common';
 import { PagerDutyClient } from '../apis/client';
+import { extractValueAtPath } from './extractEntityValue';
+import { PagerDutyServiceCustomFieldValue } from '@pagerduty/backstage-plugin-common';
 
 /**
  * A function which given an entity, determines if it should be processed for linguist tags.
@@ -199,6 +201,11 @@ export class PagerDutyEntityProcessor implements CatalogProcessor {
           entity.metadata.annotations?.['pagerduty.com/service-id'];
 
         if (serviceId) {
+          const account =
+            entity.metadata.annotations?.['pagerduty.com/account'];
+
+          await this.pushCustomFieldValues(entity, serviceId, account);
+
           const strategySetting =
             await client.getServiceDependencyStrategySetting();
 
@@ -218,8 +225,6 @@ export class PagerDutyEntityProcessor implements CatalogProcessor {
               await buildExistingDependencies(dependencyAnnotations);
 
             // Get dependencies from PagerDuty for the service
-            const account =
-              entity.metadata.annotations?.['pagerduty.com/account'];
             const dependencies = await client.getServiceDependencies(
               serviceId,
               account,
@@ -327,6 +332,43 @@ export class PagerDutyEntityProcessor implements CatalogProcessor {
     }
 
     return entity;
+  }
+
+  private async pushCustomFieldValues(
+    entity: Entity,
+    serviceId: string,
+    account: string | undefined,
+  ): Promise<void> {
+    try {
+      const fields = await client.getEnabledCustomFields(account);
+      if (fields.length === 0) return;
+
+      const values: PagerDutyServiceCustomFieldValue[] = [];
+      for (const field of fields) {
+        const result = extractValueAtPath(entity, field.backstageEntityMappingPath);
+        if (!result.ok) {
+          this.logger.warn(
+            `Skipping custom field "${field.pagerdutyCustomFieldDisplayName}" for entity ${entity.metadata.name} (service ${serviceId}): ${result.reason}`,
+          );
+          continue;
+        }
+        values.push({
+          id: field.pagerdutyCustomFieldId,
+          value: result.value,
+        });
+      }
+
+      if (values.length === 0) return;
+
+      await client.pushCustomFieldValues(serviceId, values, account);
+      this.logger.debug(
+        `Pushed ${values.length} custom field value(s) for service ${serviceId}`,
+      );
+    } catch (error) {
+      this.logger.error(
+        `Failed to push custom field values for entity ${entity.metadata.name} (service ${serviceId}): ${error}`,
+      );
+    }
   }
 }
 

--- a/plugins/backstage-plugin-entity-processor/src/processor/PagerDutyEntityProcessor.ts
+++ b/plugins/backstage-plugin-entity-processor/src/processor/PagerDutyEntityProcessor.ts
@@ -11,8 +11,6 @@ import {
 } from '@backstage/plugin-catalog-node';
 import { LocationSpec } from '@backstage/plugin-catalog-common';
 import { PagerDutyClient } from '../apis/client';
-import { extractValueAtPath } from './extractEntityValue';
-import { PagerDutyServiceCustomFieldValue } from '@pagerduty/backstage-plugin-common';
 
 /**
  * A function which given an entity, determines if it should be processed for linguist tags.
@@ -204,8 +202,6 @@ export class PagerDutyEntityProcessor implements CatalogProcessor {
           const account =
             entity.metadata.annotations?.['pagerduty.com/account'];
 
-          await this.pushCustomFieldValues(entity, serviceId, account);
-
           const strategySetting =
             await client.getServiceDependencyStrategySetting();
 
@@ -334,42 +330,6 @@ export class PagerDutyEntityProcessor implements CatalogProcessor {
     return entity;
   }
 
-  private async pushCustomFieldValues(
-    entity: Entity,
-    serviceId: string,
-    account: string | undefined,
-  ): Promise<void> {
-    try {
-      const fields = await client.getEnabledCustomFields(account);
-      if (fields.length === 0) return;
-
-      const values: PagerDutyServiceCustomFieldValue[] = [];
-      for (const field of fields) {
-        const result = extractValueAtPath(entity, field.backstageEntityMappingPath);
-        if (!result.ok) {
-          this.logger.warn(
-            `Skipping custom field "${field.pagerdutyCustomFieldDisplayName}" for entity ${entity.metadata.name} (service ${serviceId}): ${result.reason}`,
-          );
-          continue;
-        }
-        values.push({
-          id: field.pagerdutyCustomFieldId,
-          value: result.value,
-        });
-      }
-
-      if (values.length === 0) return;
-
-      await client.pushCustomFieldValues(serviceId, values, account);
-      this.logger.debug(
-        `Pushed ${values.length} custom field value(s) for service ${serviceId}`,
-      );
-    } catch (error) {
-      this.logger.error(
-        `Failed to push custom field values for entity ${entity.metadata.name} (service ${serviceId}): ${error}`,
-      );
-    }
-  }
 }
 
 export function refreshServiceDependencyAnnotations(

--- a/plugins/backstage-plugin-entity-processor/src/processor/extractEntityValue.test.ts
+++ b/plugins/backstage-plugin-entity-processor/src/processor/extractEntityValue.test.ts
@@ -1,0 +1,97 @@
+import { Entity } from '@backstage/catalog-model';
+import { extractValueAtPath } from './extractEntityValue';
+
+const entity: Entity = {
+  apiVersion: 'backstage.io/v1alpha1',
+  kind: 'Component',
+  metadata: {
+    name: 'my-service',
+    namespace: 'default',
+    description: 'My service',
+    annotations: {
+      'pagerduty.com/service-id': 'PXXX',
+      'backstage.io/source-location': 'url:https://example.com',
+    },
+    tags: ['team-a', 'go'],
+  },
+  spec: {
+    type: 'service',
+    owner: 'team-a',
+    lifecycle: 'production',
+  },
+};
+
+describe('extractValueAtPath', () => {
+  it('returns dot-path values as strings', () => {
+    expect(extractValueAtPath(entity, 'metadata.name')).toEqual({
+      ok: true,
+      value: 'my-service',
+    });
+    expect(extractValueAtPath(entity, 'spec.owner')).toEqual({
+      ok: true,
+      value: 'team-a',
+    });
+  });
+
+  it('supports bracket notation for keys with dots', () => {
+    expect(
+      extractValueAtPath(
+        entity,
+        'metadata.annotations["pagerduty.com/service-id"]',
+      ),
+    ).toEqual({ ok: true, value: 'PXXX' });
+  });
+
+  it('supports single-quoted bracket notation', () => {
+    expect(
+      extractValueAtPath(
+        entity,
+        "metadata.annotations['backstage.io/source-location']",
+      ),
+    ).toEqual({ ok: true, value: 'url:https://example.com' });
+  });
+
+  it('supports unquoted bracket notation', () => {
+    expect(extractValueAtPath(entity, 'metadata[name]')).toEqual({
+      ok: true,
+      value: 'my-service',
+    });
+  });
+
+  it('coerces non-string scalars to string', () => {
+    const e = {
+      ...entity,
+      metadata: { ...entity.metadata, count: 42 } as unknown as Entity['metadata'],
+    };
+    expect(extractValueAtPath(e, 'metadata.count')).toEqual({
+      ok: true,
+      value: '42',
+    });
+  });
+
+  it('returns not-ok when path resolves to undefined', () => {
+    const result = extractValueAtPath(entity, 'metadata.missing');
+    expect(result.ok).toBe(false);
+  });
+
+  it('returns not-ok when traversing into a missing intermediate', () => {
+    const result = extractValueAtPath(entity, 'metadata.nope.deeper');
+    expect(result.ok).toBe(false);
+  });
+
+  it('returns not-ok when path resolves to an object', () => {
+    const result = extractValueAtPath(entity, 'metadata.annotations');
+    expect(result.ok).toBe(false);
+  });
+
+  it('returns not-ok when path resolves to an array', () => {
+    const result = extractValueAtPath(entity, 'metadata.tags');
+    expect(result.ok).toBe(false);
+  });
+
+  it('returns not-ok for empty/invalid paths', () => {
+    expect(extractValueAtPath(entity, '').ok).toBe(false);
+    expect(extractValueAtPath(entity, '[]').ok).toBe(false);
+    expect(extractValueAtPath(entity, 'metadata[unterminated').ok).toBe(false);
+  });
+});

--- a/plugins/backstage-plugin-entity-processor/src/processor/extractEntityValue.ts
+++ b/plugins/backstage-plugin-entity-processor/src/processor/extractEntityValue.ts
@@ -1,0 +1,80 @@
+import { Entity } from '@backstage/catalog-model';
+
+export type ExtractResult =
+  | { ok: true; value: string }
+  | { ok: false; reason: string };
+
+export function extractValueAtPath(entity: Entity, path: string): ExtractResult {
+  if (!path || typeof path !== 'string') {
+    return { ok: false, reason: 'empty path' };
+  }
+
+  const segments = parsePath(path);
+  if (segments === null) {
+    return { ok: false, reason: `invalid path syntax: ${path}` };
+  }
+
+  let current: unknown = entity;
+  for (const segment of segments) {
+    if (current === null || current === undefined) {
+      return { ok: false, reason: `path resolves to ${current} at "${segment}"` };
+    }
+    if (typeof current !== 'object') {
+      return { ok: false, reason: `cannot index into non-object at "${segment}"` };
+    }
+    current = (current as Record<string, unknown>)[segment];
+  }
+
+  if (current === null || current === undefined) {
+    return { ok: false, reason: 'path resolves to undefined' };
+  }
+  if (typeof current === 'object') {
+    return { ok: false, reason: 'path resolves to an object/array, expected scalar' };
+  }
+  return { ok: true, value: String(current) };
+}
+
+function parsePath(path: string): string[] | null {
+  const segments: string[] = [];
+  let i = 0;
+  while (i < path.length) {
+    if (path[i] === '[') {
+      const end = findMatchingBracket(path, i);
+      if (end === -1) return null;
+      const inner = path.slice(i + 1, end).trim();
+      const unquoted = unquote(inner);
+      if (unquoted === null) return null;
+      segments.push(unquoted);
+      i = end + 1;
+      if (i < path.length && path[i] === '.') i++;
+      continue;
+    }
+
+    let end = i;
+    while (end < path.length && path[end] !== '.' && path[end] !== '[') end++;
+    const segment = path.slice(i, end);
+    if (!segment) return null;
+    segments.push(segment);
+    i = end;
+    if (path[i] === '.') i++;
+  }
+  return segments.length > 0 ? segments : null;
+}
+
+function findMatchingBracket(path: string, openIdx: number): number {
+  for (let i = openIdx + 1; i < path.length; i++) {
+    if (path[i] === ']') return i;
+  }
+  return -1;
+}
+
+function unquote(s: string): string | null {
+  if (s.length === 0) return null;
+  if (
+    (s.startsWith('"') && s.endsWith('"')) ||
+    (s.startsWith("'") && s.endsWith("'"))
+  ) {
+    return s.slice(1, -1);
+  }
+  return s;
+}

--- a/plugins/backstage-plugin-entity-processor/src/processor/index.ts
+++ b/plugins/backstage-plugin-entity-processor/src/processor/index.ts
@@ -1,1 +1,2 @@
 export { PagerDutyEntityProcessor } from './PagerDutyEntityProcessor';
+export { PagerDutyCustomFieldsProcessor } from './PagerDutyCustomFieldsProcessor';


### PR DESCRIPTION
### Description

We can create custom fields now, we need to update the PD service with the custom field values during catalog processing. This PR adds that functionality

### Affected plugin

- [ ] backstage-plugin
- [x] backstage-plugin-backend
- [ ] backstage-plugin-scaffolder-actions
- [x] backstage-plugin-entity-processor

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes have been tested in dark theme
- [x] Changes are documented
- [x] Changes generate _no new warnings_
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

If this is a breaking change 👇

- [ ] I have documented the migration process
- [ ] I have implemented necessary warnings (if it can live side by side)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
