### PR TITLE
feat: enable/disable custom fields

### DIFF
--- a/plugins/backstage-plugin-backend/src/db/PagerDutyBackendDatabase.ts
+++ b/plugins/backstage-plugin-backend/src/db/PagerDutyBackendDatabase.ts
@@ -73,6 +73,7 @@ export interface PagerDutyBackendStore {
       description?: string;
     },
   ): Promise<BackstageCustomField>;
+  setCustomFieldEnabled(id: number, enabled: boolean): Promise<BackstageCustomField>;
   deleteCustomField(id: number): Promise<void>;
   updateCustomFieldPagerDutyId(id: number, pagerdutyCustomFieldId: string): Promise<void>;
   insertSyncLog(
@@ -299,6 +300,32 @@ export class PagerDutyBackendDatabase implements PagerDutyBackendStore {
         pagerdutyCustomFieldDisplayName: updates.pagerdutyCustomFieldDisplayName,
         backstageEntityMappingPath: updates.backstageEntityMappingPath,
         description: updates.description,
+        updatedAt: new Date(),
+      });
+
+    if (rowsAffected === 0) {
+      throw new Error(`Custom field with id ${id} does not exist`);
+    }
+
+    const result = await this.db<RawDbCustomFieldRow>('pagerduty_custom_fields')
+      .where('id', id)
+      .first();
+
+    if (!result) {
+      throw new Error(`Failed to retrieve custom field after update for id: ${id}`);
+    }
+
+    return this.toBackstageCustomField(result);
+  }
+
+  async setCustomFieldEnabled(
+    id: number,
+    enabled: boolean,
+  ): Promise<BackstageCustomField> {
+    const rowsAffected = await this.db<RawDbCustomFieldRow>('pagerduty_custom_fields')
+      .where('id', id)
+      .update({
+        pagerdutyCustomFieldEnabled: enabled,
         updatedAt: new Date(),
       });
 

--- a/plugins/backstage-plugin-backend/src/service/customFieldsController.ts
+++ b/plugins/backstage-plugin-backend/src/service/customFieldsController.ts
@@ -8,6 +8,7 @@ import {
 } from '../apis/pagerduty';
 import {
   BackstageCustomFieldCreateRequest,
+  BackstageCustomFieldToggleEnabledRequest,
   BackstageCustomFieldUpdateRequest,
   BackstageCustomFieldsResponse,
   CustomFieldSyncLogCreateRequest,
@@ -254,6 +255,90 @@ export class CustomFieldsController {
       response.status(200).json({ customField });
     } catch (error) {
       this.handleUnexpectedError(error, 'updating the custom field', response);
+    }
+  }
+
+  async toggleCustomFieldEnabled(
+    request: Request,
+    response: Response,
+  ): Promise<void> {
+    try {
+      const id = parseInt(request.params.id, 10);
+      if (isNaN(id)) throw new HttpError('Invalid id parameter', 400);
+
+      const { enabled } = request.body as BackstageCustomFieldToggleEnabledRequest;
+      if (typeof enabled !== 'boolean') {
+        throw new HttpError('Invalid enabled value', 400);
+      }
+
+      const existing = await this.store.findCustomFieldById(id);
+      if (!existing) throw new HttpError('Custom field not found', 404);
+
+      // No-op if already in the requested state
+      if (existing.pagerdutyCustomFieldEnabled === enabled) {
+        response.status(200).json({ customField: existing });
+        return;
+      }
+
+      const previousEnabled = existing.pagerdutyCustomFieldEnabled;
+
+      // Step 1: Update Backstage DB first
+      try {
+        await this.store.setCustomFieldEnabled(id, enabled);
+        this.logger.info(
+          `Updated Backstage record for custom field id=${id} (enabled=${enabled})`,
+        );
+      } catch (error) {
+        this.handleDbError(error);
+      }
+
+      // Step 2: Update PagerDuty. display_name is required by the update request,
+      // so we send the existing name unchanged alongside the enabled flag.
+      const pagerDutyRequest: PagerDutyCustomFieldUpdateRequest = {
+        field: {
+          display_name: existing.pagerdutyCustomFieldDisplayName,
+          enabled,
+        },
+      };
+
+      try {
+        await updateCustomField({
+          fieldId: existing.pagerdutyCustomFieldId,
+          request: pagerDutyRequest,
+          account: existing.pagerdutySubdomain,
+        });
+        this.logger.info(
+          `Updated PagerDuty custom field enabled=${enabled}: ${existing.pagerdutyCustomFieldDisplayName} (${existing.pagerdutyCustomFieldId})`,
+        );
+      } catch (error) {
+        // Rollback: revert Backstage DB to its previous enabled state
+        try {
+          await this.store.setCustomFieldEnabled(id, previousEnabled);
+          this.logger.info(
+            `Rolled back Backstage record (id=${id}) to enabled=${previousEnabled} due to PagerDuty update failure`,
+          );
+        } catch (rollbackError) {
+          this.logger.error(
+            `CRITICAL: Failed to rollback Backstage record (id=${id}) after PagerDuty failure. Manual intervention required.`,
+            rollbackError as Error,
+          );
+        }
+
+        if (error instanceof HttpError) this.handlePagerDutyError(error);
+        throw error;
+      }
+
+      const customField = await this.store.findCustomFieldById(id);
+      this.logger.info(
+        `Successfully toggled custom field id=${id} to enabled=${enabled}`,
+      );
+      response.status(200).json({ customField });
+    } catch (error) {
+      this.handleUnexpectedError(
+        error,
+        'toggling the custom field enabled state',
+        response,
+      );
     }
   }
 

--- a/plugins/backstage-plugin-backend/src/service/router.test.ts
+++ b/plugins/backstage-plugin-backend/src/service/router.test.ts
@@ -3998,6 +3998,97 @@ describe('createRouter', () => {
     });
   });
 
+  describe('PATCH /custom-fields/:id/enabled', () => {
+    const createField = async (testId: string) => {
+      const createData = {
+        name: `Toggle Field ${testId}`,
+        entityPath: `spec.toggle_${testId}`,
+        description: 'Toggle test field',
+      };
+      mocked(fetch).mockReturnValueOnce(
+        mockedResponse(201, {
+          field: {
+            id: `PTOGGLE_${testId}`,
+            display_name: createData.name,
+            name: createData.name.toLowerCase().replace(/ /g, '_'),
+            data_type: 'string',
+            field_type: 'single_value',
+            description: createData.description,
+            enabled: true,
+          },
+        }),
+      );
+      const createResponse = await request(app)
+        .post('/custom-fields')
+        .send(createData);
+      expect(createResponse.status).toEqual(201);
+      return createResponse.body.customField.id as number;
+    };
+
+    it('disables a custom field and persists enabled=false', async () => {
+      const testId = `disable${Date.now()}`;
+      const fieldId = await createField(testId);
+
+      mocked(fetch).mockReturnValueOnce(mockedResponse(200, {}));
+      const response = await request(app)
+        .patch(`/custom-fields/${fieldId}/enabled`)
+        .send({ enabled: false });
+
+      expect(response.status).toEqual(200);
+      expect(response.body.customField.pagerdutyCustomFieldEnabled).toBe(false);
+
+      // Disabled fields should be filtered out of the enabled view
+      const enabledOnly = await request(app).get('/custom-fields?enabled=true');
+      expect(
+        enabledOnly.body.customFields.find(
+          (f: { id: number }) => f.id === fieldId,
+        ),
+      ).toBeUndefined();
+    });
+
+    it('returns 400 when enabled is not a boolean', async () => {
+      const response = await request(app)
+        .patch('/custom-fields/1/enabled')
+        .send({ enabled: 'yes' });
+      expect(response.status).toEqual(400);
+    });
+
+    it('returns 404 when the custom field does not exist', async () => {
+      const response = await request(app)
+        .patch('/custom-fields/999999/enabled')
+        .send({ enabled: false });
+      expect(response.status).toEqual(404);
+    });
+
+    it('rolls back enabled state when PagerDuty rejects re-enable over the limit', async () => {
+      const testId = `overlimit${Date.now()}`;
+      const fieldId = await createField(testId);
+
+      // First disable it successfully
+      mocked(fetch).mockReturnValueOnce(mockedResponse(200, {}));
+      const disable = await request(app)
+        .patch(`/custom-fields/${fieldId}/enabled`)
+        .send({ enabled: false });
+      expect(disable.status).toEqual(200);
+
+      // Re-enable fails because the PagerDuty hard limit is reached
+      mocked(fetch).mockReturnValueOnce(
+        mockedResponse(400, { error: { message: 'Product limit reached' } }),
+      );
+      const reEnable = await request(app)
+        .patch(`/custom-fields/${fieldId}/enabled`)
+        .send({ enabled: true });
+      expect(reEnable.status).toEqual(400);
+
+      // DB should have been rolled back to disabled
+      const all = await request(app).get('/custom-fields');
+      const field = all.body.customFields.find(
+        (f: { id: number }) => f.id === fieldId,
+      );
+      expect(field.pagerdutyCustomFieldEnabled).toBe(false);
+    });
+  });
+
   describe('GET /custom-fields', () => {
     it.each(testInputs)(
       'returns 200 with customFields array',

--- a/plugins/backstage-plugin-backend/src/service/router.ts
+++ b/plugins/backstage-plugin-backend/src/service/router.ts
@@ -550,6 +550,11 @@ export async function createRouter(
     await customFieldsController.updateCustomField(request, response);
   });
 
+  // PATCH /custom-fields/:id/enabled
+  router.patch('/custom-fields/:id/enabled', async (request, response) => {
+    await customFieldsController.toggleCustomFieldEnabled(request, response);
+  });
+
   // POST /custom-fields/sync
   router.post('/custom-fields/sync', async (request, response) => {
     await customFieldsController.syncCustomFieldValues(request, response);

--- a/plugins/backstage-plugin-common/src/types.ts
+++ b/plugins/backstage-plugin-common/src/types.ts
@@ -499,6 +499,11 @@ export type BackstageCustomFieldUpdateRequest = {
 };
 
 /** @public */
+export type BackstageCustomFieldToggleEnabledRequest = {
+  enabled: boolean;
+};
+
+/** @public */
 export type PagerDutyCustomFieldUpdateRequest = {
   field: {
     display_name: string;

--- a/plugins/backstage-plugin/dev/mockPagerDutyApi.ts
+++ b/plugins/backstage-plugin/dev/mockPagerDutyApi.ts
@@ -549,6 +549,22 @@ export const mockPagerDutyApi: PagerDutyApi = {
     error: null,
   }),
 
+  setCustomFieldEnabled: async (id: number, enabled: boolean) => ({
+    status: 'ok' as const,
+    data: {
+      id,
+      pagerdutyCustomFieldId: 'PD123',
+      pagerdutyCustomFieldDisplayName: 'Custom Field',
+      pagerdutyCustomFieldEnabled: enabled,
+      backstageEntityMappingPath: '',
+      pagerdutySubdomain: 'default',
+      description: '',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    },
+    error: null,
+  }),
+
   getSyncLogs: async () => ({
     logs: [],
     total: 0,

--- a/plugins/backstage-plugin/src/api/client.ts
+++ b/plugins/backstage-plugin/src/api/client.ts
@@ -624,6 +624,40 @@ export class PagerDutyClient implements PagerDutyApi {
     }
   }
 
+  async setCustomFieldEnabled(
+    id: number,
+    enabled: boolean,
+    account?: string,
+  ): Promise<Result<BackstageCustomField>> {
+    const options = {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json; charset=UTF-8',
+        Accept: 'application/json, text/plain, */*',
+      },
+      body: JSON.stringify({ enabled }),
+    };
+
+    let url = `${await this.config.discoveryApi.getBaseUrl(
+      'pagerduty',
+    )}/custom-fields/${id}/enabled`;
+
+    if (account) {
+      url = url.concat(`?account=${account}`);
+    }
+
+    try {
+      const response = await this.request(url, options);
+      const result = await response.json();
+      return { status: 'ok', data: result.customField, error: null };
+    } catch (error) {
+      return parseCustomFieldError(
+        error,
+        `Failed to ${enabled ? 'enable' : 'disable'} custom field`,
+      );
+    }
+  }
+
   private async findByUrl<T>(url: string): Promise<T> {
     const options = {
       method: 'GET',

--- a/plugins/backstage-plugin/src/api/types.ts
+++ b/plugins/backstage-plugin/src/api/types.ts
@@ -276,6 +276,16 @@ export interface PagerDutyApi {
   ): Promise<Result<BackstageCustomField>>;
 
   /**
+   * Enables or disables a custom field. Disabled fields are not synced to
+   * PagerDuty and do not count against the PagerDuty custom field hard limit.
+   */
+  setCustomFieldEnabled(
+    id: number,
+    enabled: boolean,
+    account?: string,
+  ): Promise<Result<BackstageCustomField>>;
+
+  /**
    * Fetches sync logs (paginated, filtered) along with the distinct
    * filter values for the given account.
    */

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/CustomFields/CustomFieldsTabPanel.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/CustomFields/CustomFieldsTabPanel.tsx
@@ -9,7 +9,9 @@ import {
   Table,
   type ColumnConfig,
 } from '@backstage/ui';
-import { Edit, MoreVert } from '@mui/icons-material';
+import { Edit, MoreVert, ToggleOff, ToggleOn } from '@mui/icons-material';
+import Snackbar from '@mui/material/Snackbar';
+import { Alert } from '@material-ui/lab';
 import { useApi } from '@backstage/core-plugin-api';
 import { pagerDutyApiRef } from '../../../api';
 import { BackstageCustomField } from '@pagerduty/backstage-plugin-common';
@@ -28,6 +30,7 @@ export const CustomFieldsTabPanel = () => {
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [editSaving, setEditSaving] = useState(false);
   const [editError, setEditError] = useState<FieldErrors | null>(null);
+  const [toggleError, setToggleError] = useState<string | null>(null);
 
   const { data: customFieldsData, isLoading } = useQuery({
     queryKey: ['pagerduty', 'customFields', account ?? ''],
@@ -63,6 +66,16 @@ export const CustomFieldsTabPanel = () => {
     setEditSaving(false);
   };
 
+  const handleToggleEnabled = useCallback(async (field: BackstageCustomField) => {
+    const nextEnabled = !field.pagerdutyCustomFieldEnabled;
+    const result = await pagerDutyApi.setCustomFieldEnabled(field.id, nextEnabled, account);
+    if (result.status === 'ok') {
+      queryClient.invalidateQueries({ queryKey: ['pagerduty', 'customFields', account ?? ''] });
+    } else {
+      setToggleError(result.error);
+    }
+  }, [pagerDutyApi, account, queryClient]);
+
   const columnConfig: ColumnConfig<BackstageCustomField>[] = useMemo(() => [
     { id: 'name', label: 'Custom Field', isRowHeader: true, isSortable: false, cell: item => <CellText title={item.pagerdutyCustomFieldDisplayName} /> },
     { id: 'entityPath', label: 'Entity Path', isRowHeader: false, isSortable: false, cell: item => <CellText title={item.backstageEntityMappingPath} /> },
@@ -75,12 +88,24 @@ export const CustomFieldsTabPanel = () => {
             <ButtonIcon icon={<MoreVert fontSize="small" />} aria-label="actions" variant="tertiary" size="small" />
             <Menu>
               <MenuItem iconStart={<Edit fontSize="small" />} onAction={() => handleOpenEditModal(item)}>Edit</MenuItem>
+              <MenuItem
+                iconStart={
+                  item.pagerdutyCustomFieldEnabled ? (
+                    <ToggleOn fontSize="small" />
+                  ) : (
+                    <ToggleOff fontSize="small" />
+                  )
+                }
+                onAction={() => handleToggleEnabled(item)}
+              >
+                {item.pagerdutyCustomFieldEnabled ? 'Disable' : 'Enable'}
+              </MenuItem>
             </Menu>
           </MenuTrigger>
         } />
       ),
     },
-  ], [handleOpenEditModal]);
+  ], [handleOpenEditModal, handleToggleEnabled]);
 
   return (
     <>
@@ -91,6 +116,9 @@ export const CustomFieldsTabPanel = () => {
           columnConfig={columnConfig}
           data={customFields}
           pagination={{ type: 'none' }}
+          rowConfig={{
+            getIsDisabled: item => !item.pagerdutyCustomFieldEnabled,
+          }}
           emptyState={
             <CustomFieldsEmptyState message='No custom fields have been added' />
           }
@@ -110,6 +138,17 @@ export const CustomFieldsTabPanel = () => {
           description: selectedCustomField.description ?? '',
         } : undefined}
       />
+
+      <Snackbar
+        open={toggleError !== null}
+        autoHideDuration={5000}
+        onClose={() => setToggleError(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      >
+        <Alert severity="error" onClose={() => setToggleError(null)}>
+          {toggleError}
+        </Alert>
+      </Snackbar>
     </>
   );
 };


### PR DESCRIPTION
### Description

Adds the ability to enable or disable a custom field directly from the Custom Fields tab.

- New **Enable/Disable** menu action per row. Disabled rows are visually greyed out.
- Disabled fields are filtered out of the enabled view and do not count against PagerDuty's custom field hard limit.
- Backend follows the existing DB-first → PagerDuty → rollback-on-failure pattern. If the PagerDuty update fails (e.g. re-enabling when the hard limit is reached), the Backstage DB is rolled back to its previous state and the error is surfaced to the user via a snackbar.

<img width="992" height="662" alt="image" src="https://github.com/user-attachments/assets/68245d6a-83ae-4bdf-a457-df2167c58bba" />


### Affected plugin

- [x] backstage-plugin
- [x] backstage-plugin-backend
- [ ] backstage-plugin-scaffolder-actions
- [ ] backstage-plugin-entity-processor

### Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes have been tested in dark theme
- [ ] Changes are documented
- [x] Changes generate _no new warnings_
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

## Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)