### PR TITLE
feat: delete custom field (DEVECO-534)

### DIFF
--- a/plugins/backstage-plugin-backend/src/apis/pagerduty.ts
+++ b/plugins/backstage-plugin-backend/src/apis/pagerduty.ts
@@ -1826,6 +1826,61 @@ export async function getCustomFields({
   }
 }
 
+export type DeleteCustomFieldProps = {
+  fieldId: string;
+  account?: string;
+};
+
+export async function deleteCustomField({
+  fieldId,
+  account,
+}: DeleteCustomFieldProps): Promise<void> {
+  const apiBaseUrl = getApiBaseUrl(account);
+  const baseUrl = `${apiBaseUrl}/services/custom_fields/${encodeURIComponent(fieldId)}`;
+  const token = await getAuthToken(account);
+
+  const options: RequestInit = {
+    method: 'DELETE',
+    headers: {
+      Authorization: token,
+      Accept: 'application/vnd.pagerduty+json;version=2',
+    },
+  };
+
+  let response: Response;
+  try {
+    response = await fetchWithRetries(baseUrl, options);
+  } catch (error) {
+    throw new Error(`Failed to delete custom field: ${error}`);
+  }
+
+  if (response.status >= 500) {
+    throw new HttpError(
+      `Failed to delete custom field. PagerDuty API returned a server error.`,
+      response.status,
+    );
+  }
+
+  switch (response.status) {
+    case 401:
+      throw new HttpError(
+        `Failed to delete custom field. Invalid credentials provided.`,
+        401,
+      );
+    case 403:
+      throw new HttpError(
+        `Failed to delete custom field. Caller is not authorized to delete this custom field.`,
+        403,
+      );
+    case 404:
+      throw new HttpError(`Custom field not found.`, 404);
+    case 429:
+      throw new HttpError(`Rate limit exceeded.`, 429);
+    default: // 204
+      break;
+  }
+}
+
 export type SetServiceCustomFieldValuesProps = {
   serviceId: string;
   request: PagerDutyServiceCustomFieldValuesRequest;

--- a/plugins/backstage-plugin-backend/src/service/customFieldsController.ts
+++ b/plugins/backstage-plugin-backend/src/service/customFieldsController.ts
@@ -3,6 +3,7 @@ import { Request, Response } from 'express';
 import { PagerDutyBackendStore } from '../db/PagerDutyBackendDatabase';
 import {
   createCustomField,
+  deleteCustomField,
   setServiceCustomFieldValues,
   updateCustomField,
 } from '../apis/pagerduty';
@@ -339,6 +340,40 @@ export class CustomFieldsController {
         'toggling the custom field enabled state',
         response,
       );
+    }
+  }
+
+  async deleteCustomField(request: Request, response: Response): Promise<void> {
+    try {
+      const id = parseInt(request.params.id, 10);
+      if (isNaN(id)) throw new HttpError('Invalid id parameter', 400);
+
+      const existing = await this.store.findCustomFieldById(id);
+      if (!existing) throw new HttpError('Custom field not found', 404);
+
+      // Step 1: Delete from PagerDuty first
+      try {
+        await deleteCustomField({
+          fieldId: existing.pagerdutyCustomFieldId,
+          account: existing.pagerdutySubdomain,
+        });
+        this.logger.info(
+          `Deleted PagerDuty custom field: ${existing.pagerdutyCustomFieldDisplayName} (${existing.pagerdutyCustomFieldId})`,
+        );
+      } catch (error) {
+        if (error instanceof HttpError) this.handlePagerDutyError(error);
+        throw error;
+      }
+
+      // Step 2: Delete from Backstage DB
+      await this.store.deleteCustomField(id);
+      this.logger.info(
+        `Deleted Backstage custom field record id=${id} (${existing.pagerdutyCustomFieldDisplayName})`,
+      );
+
+      response.status(204).end();
+    } catch (error) {
+      this.handleUnexpectedError(error, 'deleting the custom field', response);
     }
   }
 

--- a/plugins/backstage-plugin-backend/src/service/router.ts
+++ b/plugins/backstage-plugin-backend/src/service/router.ts
@@ -559,6 +559,11 @@ export async function createRouter(
     await customFieldsController.toggleCustomFieldEnabled(request, response);
   });
 
+  // DELETE /custom-fields/:id
+  router.delete('/custom-fields/:id', async (request, response) => {
+    await customFieldsController.deleteCustomField(request, response);
+  });
+
   // POST /custom-fields/sync
   router.post('/custom-fields/sync', async (request, response) => {
     await customFieldsController.syncCustomFieldValues(request, response);

--- a/plugins/backstage-plugin/dev/mockPagerDutyApi.ts
+++ b/plugins/backstage-plugin/dev/mockPagerDutyApi.ts
@@ -565,6 +565,12 @@ export const mockPagerDutyApi: PagerDutyApi = {
     error: null,
   }),
 
+  deleteCustomField: async (_id: number) => ({
+    status: 'ok' as const,
+    data: undefined,
+    error: null,
+  }),
+
   getSyncLogs: async () => ({
     logs: [],
     total: 0,

--- a/plugins/backstage-plugin/src/api/client.ts
+++ b/plugins/backstage-plugin/src/api/client.ts
@@ -658,6 +658,34 @@ export class PagerDutyClient implements PagerDutyApi {
     }
   }
 
+  async deleteCustomField(
+    id: number,
+    account?: string,
+  ): Promise<Result<void>> {
+    const options = {
+      method: 'DELETE',
+      headers: {
+        Accept: 'application/json, text/plain, */*',
+      },
+    };
+
+    let url = `${await this.config.discoveryApi.getBaseUrl(
+      'pagerduty',
+    )}/custom-fields/${id}`;
+
+    if (account) {
+      url = url.concat(`?account=${account}`);
+    }
+
+    try {
+      await this.request(url, options);
+      return { status: 'ok', data: undefined, error: null };
+    } catch (error) {
+      const result = parseCustomFieldError(error, 'Failed to delete custom field');
+      return { status: 'error', data: null, error: result.error! };
+    }
+  }
+
   private async findByUrl<T>(url: string): Promise<T> {
     const options = {
       method: 'GET',

--- a/plugins/backstage-plugin/src/api/types.ts
+++ b/plugins/backstage-plugin/src/api/types.ts
@@ -286,6 +286,14 @@ export interface PagerDutyApi {
   ): Promise<Result<BackstageCustomField>>;
 
   /**
+   * Deletes a custom field from both Backstage and PagerDuty, reclaiming the slot.
+   */
+  deleteCustomField(
+    id: number,
+    account?: string,
+  ): Promise<Result<void>>;
+
+  /**
    * Fetches sync logs (paginated, filtered) along with the distinct
    * filter values for the given account.
    */

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/CustomFields/CustomFieldsTabPanel.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/CustomFields/CustomFieldsTabPanel.tsx
@@ -9,7 +9,7 @@ import {
   Table,
   type ColumnConfig,
 } from '@backstage/ui';
-import { Edit, MoreVert, ToggleOff, ToggleOn } from '@mui/icons-material';
+import { Delete, Edit, MoreVert, ToggleOff, ToggleOn } from '@mui/icons-material';
 import Snackbar from '@mui/material/Snackbar';
 import { Alert } from '@material-ui/lab';
 import { useApi } from '@backstage/core-plugin-api';
@@ -20,6 +20,7 @@ import { TableSkeleton } from '../MappingsTable/TableSkeleton';
 import { useAccountContext } from '../AccountContext';
 import { toFieldErrors } from './customFieldErrors';
 import { CustomFieldsEmptyState } from './CustomFieldsEmptyState';
+import { DeleteCustomFieldDialog } from './DeleteCustomFieldDialog';
 
 export const CustomFieldsTabPanel = () => {
   const pagerDutyApi = useApi(pagerDutyApiRef);
@@ -31,6 +32,7 @@ export const CustomFieldsTabPanel = () => {
   const [editSaving, setEditSaving] = useState(false);
   const [editError, setEditError] = useState<FieldErrors | null>(null);
   const [toggleError, setToggleError] = useState<string | null>(null);
+  const [fieldToDelete, setFieldToDelete] = useState<BackstageCustomField | null>(null);
 
   const { data: customFieldsData, isLoading } = useQuery({
     queryKey: ['pagerduty', 'customFields', account ?? ''],
@@ -100,6 +102,7 @@ export const CustomFieldsTabPanel = () => {
               >
                 {item.pagerdutyCustomFieldEnabled ? 'Disable' : 'Enable'}
               </MenuItem>
+              <MenuItem iconStart={<Delete fontSize="small" />} onAction={() => setFieldToDelete(item)}>Delete</MenuItem>
             </Menu>
           </MenuTrigger>
         } />
@@ -137,6 +140,12 @@ export const CustomFieldsTabPanel = () => {
           entityPath: selectedCustomField.backstageEntityMappingPath,
           description: selectedCustomField.description ?? '',
         } : undefined}
+      />
+
+      <DeleteCustomFieldDialog
+        field={fieldToDelete}
+        onClose={() => setFieldToDelete(null)}
+        onSuccess={() => setFieldToDelete(null)}
       />
 
       <Snackbar

--- a/plugins/backstage-plugin/src/components/PagerDutyPage/CustomFields/DeleteCustomFieldDialog.tsx
+++ b/plugins/backstage-plugin/src/components/PagerDutyPage/CustomFields/DeleteCustomFieldDialog.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogBody,
+  DialogFooter,
+  DialogHeader,
+  Flex,
+  Text,
+} from '@backstage/ui';
+import { useApi } from '@backstage/core-plugin-api';
+import { BackstageCustomField } from '@pagerduty/backstage-plugin-common';
+import { pagerDutyApiRef } from '../../../api';
+import { useAccountContext } from '../AccountContext';
+
+interface DeleteCustomFieldDialogProps {
+  field: BackstageCustomField | null;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export const DeleteCustomFieldDialog = ({
+  field,
+  onClose,
+  onSuccess,
+}: DeleteCustomFieldDialogProps) => {
+  const pagerDutyApi = useApi(pagerDutyApiRef);
+  const queryClient = useQueryClient();
+  const { selectedAccount } = useAccountContext();
+  const account = selectedAccount || undefined;
+
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleClose = () => {
+    setError(null);
+    onClose();
+  };
+
+  const handleConfirm = async () => {
+    if (!field) return;
+    setDeleting(true);
+    setError(null);
+    const result = await pagerDutyApi.deleteCustomField(field.id, account);
+    if (result.status === 'ok') {
+      queryClient.invalidateQueries({ queryKey: ['pagerduty', 'customFields', account ?? ''] });
+      onSuccess();
+    } else {
+      setError(result.error);
+    }
+    setDeleting(false);
+  };
+
+  return (
+    <Dialog
+      isOpen={field !== null}
+      onOpenChange={isOpen => !isOpen && handleClose()}
+      width={440}
+    >
+      <DialogHeader>Delete Custom Field</DialogHeader>
+      <DialogBody>
+        {error && (
+          <Box style={{ marginBottom: 16 }}>
+            <Text variant="body-small" color="danger">{error}</Text>
+          </Box>
+        )}
+        <Text>
+          Are you sure you want to delete <strong>{field?.pagerdutyCustomFieldDisplayName}</strong>? This will remove the custom field from PagerDuty and reclaim its slot.
+        </Text>
+      </DialogBody>
+      <DialogFooter>
+        <Flex gap="2" justify="end">
+          <Button variant="secondary" isDisabled={deleting} onClick={handleClose}>
+            Cancel
+          </Button>
+          <Button variant="primary" isDisabled={deleting} onClick={handleConfirm}>
+            {deleting ? 'Deleting…' : 'Delete'}
+          </Button>
+        </Flex>
+      </DialogFooter>
+    </Dialog>
+  );
+};


### PR DESCRIPTION
## Summary

Implements end-to-end delete for Backstage custom fields ([DEVECO-534](https://pagerduty.atlassian.net/browse/DEVECO-534)).

Deleting a custom field removes it from PagerDuty (reclaiming the slot against the 15-field hard limit) and then removes the local Backstage DB record.

## Changes

* **Backend API** (`src/apis/pagerduty.ts`) — new `deleteCustomField()` calling `DELETE /services/custom_fields/:fieldId` on the PagerDuty API
* **Controller** (`customFieldsController.ts`) — new `deleteCustomField()` method: deletes from PagerDuty first, then removes the Backstage DB record; returns 204
* **Router** (`router.ts`) — new `DELETE /custom-fields/:id` route
* **Frontend API** (`types.ts`, `client.ts`) — `deleteCustomField(id, account?)` added to interface and client
* **Mock API** (`mockPagerDutyApi.ts`) — stub implementation added
* **UI** (`DeleteCustomFieldDialog.tsx`) — self-contained dialog component that owns its own state, API call, and cache invalidation; parent only passes `field` / `onClose` / `onSuccess`
* **UI** (`CustomFieldsTabPanel.tsx`) — Delete menu item added; delete state reduced to a single `fieldToDelete` piece of state

[DEVECO-534]: https://pagerduty.atlassian.net/browse/DEVECO-534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ