### PR TITLE
fix(frontend): migrate entity cards to configSchema

### DIFF
--- a/.changeset/curly-cards-config.md
+++ b/.changeset/curly-cards-config.md
@@ -1,0 +1,5 @@
+---
+'@pagerduty/backstage-plugin': patch
+---
+
+Migrate alpha entity card configuration to Backstage's Standard Schema-based `configSchema` API.

--- a/plugins/backstage-plugin/package.json
+++ b/plugins/backstage-plugin/package.json
@@ -64,7 +64,8 @@
     "luxon": "^3.4.1",
     "material-react-table": "^2.13.0",
     "react-use": "^17.2.4",
-    "validate-color": "^2.2.4"
+    "validate-color": "^2.2.4",
+    "zod": "^4.0.0"
   },
   "peerDependencies": {
     "react": "^18.0.0 || ^20.0.0",

--- a/plugins/backstage-plugin/src/alpha/entity-cards.test.ts
+++ b/plugins/backstage-plugin/src/alpha/entity-cards.test.ts
@@ -1,0 +1,45 @@
+import { pagerDutyEntityCard, pagerDutyEntitySmallCard } from './entity-cards';
+
+function getConfigSchema(extension: unknown) {
+  return (
+    extension as {
+      configSchema: { parse: (input: unknown) => unknown };
+    }
+  ).configSchema;
+}
+
+describe('PagerDuty entity card configuration', () => {
+  it('supports configuration for the full entity card', () => {
+    const configSchema = getConfigSchema(pagerDutyEntityCard);
+
+    expect(configSchema).toBeDefined();
+    expect(
+      configSchema.parse({
+        readOnly: true,
+        disableChangeEvents: true,
+        disableOnCall: true,
+      }),
+    ).toEqual({
+      readOnly: true,
+      disableChangeEvents: true,
+      disableOnCall: true,
+    });
+  });
+
+  it('supports configuration for the small entity card', () => {
+    const configSchema = getConfigSchema(pagerDutyEntitySmallCard);
+
+    expect(configSchema).toBeDefined();
+    expect(
+      configSchema.parse({
+        readOnly: true,
+        disableOnCall: true,
+        disableInsights: true,
+      }),
+    ).toEqual({
+      readOnly: true,
+      disableOnCall: true,
+      disableInsights: true,
+    });
+  });
+});

--- a/plugins/backstage-plugin/src/alpha/entity-cards.tsx
+++ b/plugins/backstage-plugin/src/alpha/entity-cards.tsx
@@ -1,16 +1,15 @@
 import { compatWrapper } from '@backstage/core-compat-api';
 import { EntityCardBlueprint } from '@backstage/plugin-catalog-react/alpha';
+import { z } from 'zod';
 import { PAGERDUTY_INTEGRATION_KEY, PAGERDUTY_SERVICE_ID } from '../components/constants';
 
 /** @alpha */
 export const pagerDutyEntityCard = EntityCardBlueprint.makeWithOverrides({
   name: 'EntityPagerDutyCard',
-  config: {
-    schema: {
-      readOnly: z => z.boolean().optional(),
-      disableChangeEvents: z => z.boolean().optional(),
-      disableOnCall: z => z.boolean().optional(),
-    }
+  configSchema: {
+    readOnly: z.boolean().optional(),
+    disableChangeEvents: z.boolean().optional(),
+    disableOnCall: z.boolean().optional(),
   },
   factory(originalFactory, { config }) {
     return originalFactory({
@@ -37,12 +36,10 @@ export const pagerDutyEntityCard = EntityCardBlueprint.makeWithOverrides({
 export const pagerDutyEntitySmallCard = EntityCardBlueprint.makeWithOverrides({
   name: 'EntityPagerDutySmallCard',
   disabled: true,
-  config: {
-    schema: {
-      readOnly: z => z.boolean().optional(),
-      disableOnCall: z => z.boolean().optional(),
-      disableInsights: z => z.boolean().optional(),
-    },
+  configSchema: {
+    readOnly: z.boolean().optional(),
+    disableOnCall: z.boolean().optional(),
+    disableInsights: z.boolean().optional(),
   },
   factory(originalFactory, { config }) {
     return originalFactory({

--- a/yarn.lock
+++ b/yarn.lock
@@ -10346,6 +10346,7 @@ __metadata:
     react-use: "npm:^17.2.4"
     uuid: "npm:^10.0.0"
     validate-color: "npm:^2.2.4"
+    zod: "npm:^4.0.0"
   peerDependencies:
     react: ^18.0.0 || ^20.0.0
     react-dom: ^18.0.0 || ^20.0.0


### PR DESCRIPTION
### Description

Migrates the PagerDuty alpha entity cards from the deprecated `config.schema` format to Backstage's Standard Schema-based `configSchema` API.

This fixes frontend initialization failures during automatic frontend package discovery on Backstage 1.54.

**Issue number:** #180

### Affected plugin

- [x] backstage-plugin
- [ ] backstage-plugin-backend
- [ ] backstage-plugin-scaffolder-actions
- [ ] backstage-plugin-entity-processor

### Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [ ] Changes have been tested in dark theme
- [x] Changes are documented
- [ ] Changes generate _no new warnings_
- [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)

Validation performed:

- Focused entity-card configuration tests
- Plugin TypeScript check
- Plugin build
- Plugin lint

### Acknowledgement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer:** We value your time and bandwidth. As such, any pull requests created on non-triaged issues might not be successful.
